### PR TITLE
Corrected minor typo in cow.fi meta-description

### DIFF
--- a/const/meta.ts
+++ b/const/meta.ts
@@ -3,7 +3,7 @@ const API_BASE_URL = "https://api.cow.fi"
 export const siteConfig = {
   title: 'CoW Protocol',
   description: 'CoW Protocol lets you swap assets MEV protected at the best exchange rate by leveraging its batch settlement layer built on top of AMMs and DEX Aggregators.',
-  descriptionShort: 'Ethereums MetaDEX Aggregator',
+  descriptionShort: 'Ethereum\'s MetaDEX Aggregator',
   url: {
     root: "https://cow.fi",
     swap: "https://cowswap.exchange",


### PR DESCRIPTION
The meta description of cow.fi was reading "Ethereu**ms** MetaDEX Aggregator". This small PR fixes this.

![image](https://user-images.githubusercontent.com/64154020/174177835-972fe747-a3cb-41f7-8371-c7bb9cf6c83b.png)
