### PR TITLE
Dune integration and get Trades count and Surplus

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,28 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import { useRef } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { default as dark } from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
 
-import { getTotalTrades } from 'services/dune'
+import { getTotalTrades, getTotalSurplus } from 'services/dune'
 
 import { ExternalLink } from '@/const/styles/global'
 import { siteConfig } from '@/const/meta'
@@ -239,12 +239,13 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = siteConfig
   const { social } = siteConfig
   const { volumeUsd } = await cowSdk.cowSubgraphApi.getTotals()
-  const totalTrades = await getTotalTrades()
+  const trades = await getTotalTrades()
+  const surplus = await getTotalSurplus()
   
   const metricsData = [
     {label: "Total Volume", value: numberFormatter.format(+volumeUsd) + '+'},
     
-    {label: "All Time Trades", value: numberFormatter.format(totalTrades.tradesCount) + '+'},
+    {label: "All Time Trades", value: numberFormatter.format(trades.totalCount) + '+'},
 
     // https://dune.xyz/gnosis.protocol/GPv2-Trader-Surplus
     //  Resonable + Unusual
@@ -256,10 +257,12 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
     props: {      
       metricsData: {
         totalVolume: numberFormatter.format(+volumeUsd) + '+',
-        tradesCount: numberFormatter.format(totalTrades.tradesCount),
-        tradesCountLastModified: totalTrades.lastModified.toISOString(),
-        totalSurplus: "$64M+",
-        totalSurplusLastModified: totalTrades.lastModified.toISOString()
+
+        tradesCount: numberFormatter.format(trades.totalCount) + '+',
+        tradesCountLastModified: trades.lastModified.toISOString(),
+
+        totalSurplus: numberFormatter.format(surplus.totalCount) + '+',
+        totalSurplusLastModified: surplus.lastModified.toISOString()
       },
       siteConfigData
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,9 +6,10 @@ import { useRef } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { default as dark } from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
 
+import { getTotalTrades } from 'services/dune'
+
 import { ExternalLink } from '@/const/styles/global'
 import { siteConfig } from '@/const/meta'
-import { GET_QUOTE } from '@/const/api'
 
 import Layout from '@/components/Layout'
 import { ButtonWrapper } from '@/components/Button'
@@ -19,6 +20,7 @@ import Button from '@/components/Button'
 
 import { CowSdk } from '@cowprotocol/cow-sdk'
 import { intlFormat } from 'date-fns/esm';
+import { GET_QUOTE } from '@/const/api';
 
 const cowSdk = new CowSdk(1)
 const numberFormatter = Intl.NumberFormat('en', { notation: 'compact' })
@@ -215,11 +217,12 @@ export const getStaticProps: GetStaticProps = async () => {
   const siteConfigData = siteConfig
   const { social } = siteConfig
   const { volumeUsd } = await cowSdk.cowSubgraphApi.getTotals()
+  const totalTrades = await getTotalTrades()
   
   const metricsData = [
     {label: "Total Volume", value: numberFormatter.format(+volumeUsd) + '+'},
     
-    {label: "All Time Trades", value: "321K+"},
+    {label: "All Time Trades", value: totalTrades.tradesCount},
 
     // https://dune.xyz/gnosis.protocol/GPv2-Trader-Surplus
     //  Resonable + Unusual

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -222,7 +222,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const metricsData = [
     {label: "Total Volume", value: numberFormatter.format(+volumeUsd) + '+'},
     
-    {label: "All Time Trades", value: totalTrades.tradesCount},
+    {label: "All Time Trades", value: numberFormatter.format(totalTrades.tradesCount) + '+'},
 
     // https://dune.xyz/gnosis.protocol/GPv2-Trader-Surplus
     //  Resonable + Unusual

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,21 @@ const cowSdk = new CowSdk(1)
 const numberFormatter = Intl.NumberFormat('en', { notation: 'compact' })
 const DATA_CACHE_TIME_SECONDS = 5 * 60 // Cache 5min
 
-export default function Home({ totals, metricsData, siteConfigData }) {
+
+interface MetricsData {
+  totalVolume: string
+  tradesCount: string
+  tradesCountLastModified: string
+  totalSurplus: string
+  totalSurplusLastModified: string
+  
+}
+interface HomeProps {
+  metricsData: MetricsData
+  siteConfigData: typeof siteConfig
+}
+
+export default function Home({ metricsData, siteConfigData }: HomeProps) {
   const { title, descriptionShort, social, url } = siteConfigData
 
   const scrollToElRef = useRef(null);
@@ -66,12 +80,20 @@ export default function Home({ totals, metricsData, siteConfigData }) {
           <h2>A fast-growing trading protocol</h2>
           <SubTitle align="center">Trade on CoW Protocol for <br /> better prices, gas cost savings and extra secure MEV protection. <ExternalLink href="https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2" target="_blank" rel="noreferrer">View analytics</ExternalLink></SubTitle>
           <Metrics>
-            {metricsData.map(({ label, value }, i) =>
-              <div key={i}>
-                <b>{value}</b>
-                <i>{label}</i>
-              </div>
-            )}
+            <>
+            <div>
+              <b>{metricsData.totalVolume}</b>
+              <i>Total Volume</i>
+            </div>
+            <div>
+              <b data-last-modified={metricsData.tradesCountLastModified}>{metricsData.tradesCount}</b>
+              <i>All Time Trades</i>
+            </div>
+            <div>
+              <b data-last-modified={metricsData.totalSurplusLastModified}>{metricsData.totalSurplus}</b>
+              <i>Surplus generated for users</i>
+            </div>
+            </>
           </Metrics>
         </div>
       </Section>
@@ -213,7 +235,7 @@ export default function Home({ totals, metricsData, siteConfigData }) {
 }
 
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = siteConfig
   const { social } = siteConfig
   const { volumeUsd } = await cowSdk.cowSubgraphApi.getTotals()
@@ -231,7 +253,16 @@ export const getStaticProps: GetStaticProps = async () => {
 
 
   return {
-    props: { metricsData, siteConfigData, social },
+    props: {      
+      metricsData: {
+        totalVolume: numberFormatter.format(+volumeUsd) + '+',
+        tradesCount: numberFormatter.format(totalTrades.tradesCount),
+        tradesCountLastModified: totalTrades.lastModified.toISOString(),
+        totalSurplus: "$64M+",
+        totalSurplusLastModified: totalTrades.lastModified.toISOString()
+      },
+      siteConfigData
+    },
     revalidate: DATA_CACHE_TIME_SECONDS,
   }
 }

--- a/services/dune.tsx
+++ b/services/dune.tsx
@@ -6,16 +6,16 @@ assert(DUNE_API_KEY, "DUNE_API_KEY environment var is required")
 // TODO: getFromDune will be moved in a future PR to the SDK
 interface MetadataQuery {
   executed_at: string,
-  job_id: string,
-  query_duration_millis: number,
-  query_version: number,
-  result_bytes: number
-  result_rows: number
+  // job_id: string,
+  // query_duration_millis: number,
+  // query_version: number,
+  // result_bytes: number
+  // result_rows: number
 }
 
 interface GetFromDuneResult<T> {
   metadata: MetadataQuery
-  column_names: string[]
+  // column_names: string[]
   rows: T[]
 }
 

--- a/services/dune.tsx
+++ b/services/dune.tsx
@@ -33,24 +33,28 @@ export async function getFromDune<T>(queryId: number): Promise<GetFromDuneResult
 // ------ End of TODO
 
 const TOTAL_TRADES_COUNT_QUERY_ID = 1034337
+const TOTAL_SURPLUS_COUNT_QUERY_ID = 270604
 
 
-interface GetTotalTradesResult {
-  tradesCount: number
+interface TotalCount {
+  totalCount: number
   lastModified: Date
 }
 
-export async function getTotalTrades(): Promise<GetTotalTradesResult> {
+export async function _getTotalCount(queryId: number): Promise<TotalCount> {
   const queryResut = await getFromDune<{ count: number }>(TOTAL_TRADES_COUNT_QUERY_ID)
 
   // Expect one row
   assert(
     queryResut.rows.length === 1, 
-    `Total Trades Dune query (${TOTAL_TRADES_COUNT_QUERY_ID}) must return just one row. Returned ${queryResut.rows.length}`
+    `Total Count Dune query (${queryId}) must return just one row. Returned ${queryResut.rows.length}`
   )
 
   return {
-    tradesCount: queryResut.rows[0].count,
+    totalCount: queryResut.rows[0].count,
     lastModified: new Date(queryResut.metadata.executed_at)
   }
 }
+
+export const getTotalTrades = () => _getTotalCount(TOTAL_TRADES_COUNT_QUERY_ID)
+export const getTotalSurplus = () => _getTotalCount(TOTAL_SURPLUS_COUNT_QUERY_ID)

--- a/services/dune.tsx
+++ b/services/dune.tsx
@@ -1,0 +1,56 @@
+import {strict as assert} from 'node:assert'
+
+const DUNE_API_KEY = process.env.DUNE_API_KEY
+assert(DUNE_API_KEY, "DUNE_API_KEY environment var is required")
+
+// TODO: getFromDune will be moved in a future PR to the SDK
+interface MetadataQuery {
+  executed_at: string,
+  job_id: string,
+  query_duration_millis: number,
+  query_version: number,
+  result_bytes: number
+  result_rows: number
+}
+
+interface GetFromDuneResult<T> {
+  metadata: MetadataQuery
+  column_names: string[]
+  rows: T[]
+}
+
+export async function getFromDune<T>(queryId: number): Promise<GetFromDuneResult<T>> {
+  const response = await fetch(`https://api.dune.com/api/v0/query/${queryId}/results`, {
+    headers: {
+      accept: "application/json",
+      "X-DUNE-API-KEY": DUNE_API_KEY
+    }
+  })
+
+  return await response.json()
+}
+
+// ------ End of TODO
+
+const TOTAL_TRADES_COUNT_QUERY_ID = 1034337
+
+
+interface GetTotalTradesResult {
+  tradesCount: number
+  lastModified: Date
+}
+
+export async function getTotalTrades(): Promise<GetTotalTradesResult> {
+  const queryResut = await getFromDune<{ count: number }>(TOTAL_TRADES_COUNT_QUERY_ID)
+
+  // Expect one row
+  assert(
+    queryResut.rows.length === 1, 
+    `Total Trades Dune query (${TOTAL_TRADES_COUNT_QUERY_ID}) must return just one row. Returned ${queryResut.rows.length}`
+  )
+
+  return {
+    tradesCount: queryResut.rows[0].count,
+    lastModified: new Date(queryResut.metadata.executed_at)
+  }
+}

--- a/services/dune.tsx
+++ b/services/dune.tsx
@@ -42,7 +42,8 @@ interface TotalCount {
 }
 
 export async function _getTotalCount(queryId: number): Promise<TotalCount> {
-  const queryResut = await getFromDune<{ count: number }>(TOTAL_TRADES_COUNT_QUERY_ID)
+  const queryResut = await getFromDune<{ count: number }>(queryId)
+  console.log('queryResut', queryId, queryResut)
 
   // Expect one row
   assert(
@@ -57,4 +58,16 @@ export async function _getTotalCount(queryId: number): Promise<TotalCount> {
 }
 
 export const getTotalTrades = () => _getTotalCount(TOTAL_TRADES_COUNT_QUERY_ID)
-export const getTotalSurplus = () => _getTotalCount(TOTAL_SURPLUS_COUNT_QUERY_ID)
+
+export const getTotalSurplus = async (): Promise<TotalCount> => {
+  const queryResut = await getFromDune<{ surplus_type: string, total_surplus_usd: number }>(TOTAL_SURPLUS_COUNT_QUERY_ID)
+
+  const totalCount = queryResut.rows.reduce((totalSurplus, surplus) => {
+    return totalSurplus + surplus.total_surplus_usd
+  }, 0)
+
+  return {
+    totalCount,
+    lastModified: new Date(queryResut.metadata.executed_at)
+  }
+}


### PR DESCRIPTION
This PR integrates with Dune API.

Additionally, this integration is used to fetch the information from the total count of trades, and the total surplus, which for now is not available in the graph.

![image](https://user-images.githubusercontent.com/2352112/179217625-cbe47323-39be-4a51-9ddb-bafed5c316e3.png)


## Privacy considerations
No API KEY has been leaked in this PR. It uses an env var, and the code of the call runs only in the server, and is removed before sending it to the UI. The UI is statically generated

> This has been configured already in vercel for all envs


## Performance
The UI shouldn't suffer from performance issues because this is statically generated in the background. 

## Dune dependency
This PR adds obviously a dependency with Dune. We rely on a specific format for their response.


## Not included
We will likely want in the future (maybe after some experimentation) to expose this in the SDK. For now is even better not to do it because:
- Dune is not stable, interfaces might change, so its better not expose this for now
- People won't have access to the API KEY

## Bonus
Improved a bit the types for the props of the index page