### PR TITLE
Load stats from config + deprecate Dune v0

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,8 +6,6 @@ import { useRef } from 'react'
 // import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 // import { default as dark } from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
 
-import { getTotalTrades, getTotalSurplus } from 'services/dune'
-
 // import { ExternalLink } from '@/const/styles/global'
 import { siteConfig } from '@/const/meta'
 import { Color } from 'const/styles/variables'
@@ -19,6 +17,7 @@ import SocialList from '@/components/SocialList'
 import Button from '@/components/Button'
 
 import { CowSdk } from '@cowprotocol/cow-sdk'
+import { getCowStats } from 'services/config'
 // import { intlFormat } from 'date-fns/esm';
 // import { GET_QUOTE } from '@/const/api';
 
@@ -283,8 +282,10 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = siteConfig
   const { social } = siteConfig
   const { volumeUsd, volumeEth } = await cowSdk.cowSubgraphApi.getTotals()
-  const trades = await getTotalTrades()
-  const surplus = await getTotalSurplus()
+  const { surplus, totalTrades, lastModified } = await getCowStats()
+
+  const totalSurplus = surplus.reasonable + surplus.unusual
+  const lastModifiedFormatted = lastModified.toISOString()
   
   // const metricsData = [
   //   {label: "Total Volume", value: numberFormatter.format(+volumeUsd) + '+'},
@@ -303,11 +304,11 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
         totalVolume: numberFormatter.format(+volumeUsd) + '+',
         totalVolumeETH: numberFormatter.format(+volumeEth) + '+',
 
-        tradesCount: numberFormatter.format(trades.totalCount) + '+',
-        tradesCountLastModified: trades.lastModified.toISOString(),
+        tradesCount: numberFormatter.format(totalTrades) + '+',
+        tradesCountLastModified: lastModifiedFormatted,
 
-        totalSurplus: numberFormatter.format(surplus.totalCount) + '+',
-        totalSurplusLastModified: surplus.lastModified.toISOString()
+        totalSurplus: numberFormatter.format(totalSurplus) + '+',
+        totalSurplusLastModified: lastModifiedFormatted
       },
       siteConfigData
     },

--- a/services/config.tsx
+++ b/services/config.tsx
@@ -1,0 +1,25 @@
+const CONFIG_PATH = 'https://raw.githubusercontent.com/cowprotocol/cow-fi/configuration/config/'
+
+export interface CowStats {
+  totalTrades: number, // https://dune.com/queries/1034337
+  surplus: { // https://dune.com/queries/270604
+    reasonable: number,
+    unusual: number
+  },
+  lastModified: Date
+}
+
+type CowStatsConfig = Omit<CowStats, 'lastModified'> & { lastModified: string }
+
+async function getFromConfig<T>(configFilePath: string): Promise<T> {
+  const response = await fetch(CONFIG_PATH + `${configFilePath}`)
+  return await response.json()
+}
+
+export async function getCowStats(): Promise<CowStats> {
+  const statsConfig = await getFromConfig<CowStatsConfig>('stats.json')
+  return {
+    ...statsConfig,
+    lastModified: new Date(statsConfig.lastModified)
+  }
+}

--- a/services/dune.tsx
+++ b/services/dune.tsx
@@ -57,8 +57,14 @@ export async function _getTotalCount(queryId: number): Promise<TotalCount> {
   }
 }
 
+/**
+ * @deprecated
+ */
 export const getTotalTrades = () => _getTotalCount(TOTAL_TRADES_COUNT_QUERY_ID)
 
+/**
+ * @deprecated
+ */
 export const getTotalSurplus = async (): Promise<TotalCount> => {
   const queryResut = await getFromDune<{ surplus_type: string, total_surplus_usd: number }>(TOTAL_SURPLUS_COUNT_QUERY_ID)
 


### PR DESCRIPTION
This PR replace the old deprecated API from Dune for a simple config file. 

This PR is an alternative to https://github.com/cowprotocol/cow-fi/pull/33 to make the stats more dynamic (so we can change without deploying). The idea is to buy time so we are not forced to use Dune v1 which is still undocumented and its not a priority for us.

## How does it work?
There's a new branch `configuration` where we will read from now on the stats. So we can change it from time to time without redeploying the website.

https://raw.githubusercontent.com/cowprotocol/cow-fi/configuration/config/stats.json

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/2352112/191972781-c8c35a3c-ad3c-4e44-a699-4c38f3e1e819.png">

## Deprecation of Dune v0
The plan is to adapt dune, but not now (still waiting for the right time to do so). 

So this PR just stops using it, and for now we just deprecate it, so at least if you try to use it in the project you will see it strikedtrough:

<img width="463" alt="image" src="https://user-images.githubusercontent.com/2352112/191973240-11a1013b-a66c-48c5-89df-f44b02d9648a.png">


## Test
- Verify the JSON and the website info matches. Keep in mind there's some rounding