### PR TITLE
Release/0.5.0

### DIFF
--- a/const/meta.ts
+++ b/const/meta.ts
@@ -10,7 +10,7 @@ export const siteConfig = {
     docs: "https://docs.cow.fi",
     api: API_BASE_URL + "/mainnet",
     apiDocs: API_BASE_URL + "/docs",
-    analytics: "https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2",
+    analytics: "https://dune.com/cowprotocol/Gnosis-Protocol-V2",
     explorer: "https://explorer.cow.fi",
   },
   greenhouse: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,8 +6,6 @@ import { useRef } from 'react'
 // import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 // import { default as dark } from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
 
-import { getTotalTrades, getTotalSurplus } from 'services/dune'
-
 // import { ExternalLink } from '@/const/styles/global'
 import { siteConfig } from '@/const/meta'
 import { Color } from 'const/styles/variables'
@@ -19,6 +17,7 @@ import SocialList from '@/components/SocialList'
 import Button from '@/components/Button'
 
 import { CowSdk } from '@cowprotocol/cow-sdk'
+import { getCowStats } from 'services/config'
 // import { intlFormat } from 'date-fns/esm';
 // import { GET_QUOTE } from '@/const/api';
 
@@ -283,8 +282,10 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = siteConfig
   const { social } = siteConfig
   const { volumeUsd, volumeEth } = await cowSdk.cowSubgraphApi.getTotals()
-  const trades = await getTotalTrades()
-  const surplus = await getTotalSurplus()
+  const { surplus, totalTrades, lastModified } = await getCowStats()
+
+  const totalSurplus = surplus.reasonable + surplus.unusual
+  const lastModifiedFormatted = lastModified.toISOString()
   
   // const metricsData = [
   //   {label: "Total Volume", value: numberFormatter.format(+volumeUsd) + '+'},
@@ -303,11 +304,11 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
         totalVolume: numberFormatter.format(+volumeUsd) + '+',
         totalVolumeETH: numberFormatter.format(+volumeEth) + '+',
 
-        tradesCount: numberFormatter.format(trades.totalCount) + '+',
-        tradesCountLastModified: trades.lastModified.toISOString(),
+        tradesCount: numberFormatter.format(totalTrades) + '+',
+        tradesCountLastModified: lastModifiedFormatted,
 
-        totalSurplus: numberFormatter.format(surplus.totalCount) + '+',
-        totalSurplusLastModified: surplus.lastModified.toISOString()
+        totalSurplus: numberFormatter.format(totalSurplus) + '+',
+        totalSurplusLastModified: lastModifiedFormatted
       },
       siteConfigData
     },

--- a/services/config.tsx
+++ b/services/config.tsx
@@ -1,0 +1,25 @@
+const CONFIG_PATH = 'https://raw.githubusercontent.com/cowprotocol/cow-fi/configuration/config/'
+
+export interface CowStats {
+  totalTrades: number, // https://dune.com/queries/1034337
+  surplus: { // https://dune.com/queries/270604
+    reasonable: number,
+    unusual: number
+  },
+  lastModified: Date
+}
+
+type CowStatsConfig = Omit<CowStats, 'lastModified'> & { lastModified: string }
+
+async function getFromConfig<T>(configFilePath: string): Promise<T> {
+  const response = await fetch(CONFIG_PATH + `${configFilePath}`)
+  return await response.json()
+}
+
+export async function getCowStats(): Promise<CowStats> {
+  const statsConfig = await getFromConfig<CowStatsConfig>('stats.json')
+  return {
+    ...statsConfig,
+    lastModified: new Date(statsConfig.lastModified)
+  }
+}

--- a/services/dune.tsx
+++ b/services/dune.tsx
@@ -57,8 +57,14 @@ export async function _getTotalCount(queryId: number): Promise<TotalCount> {
   }
 }
 
+/**
+ * @deprecated
+ */
 export const getTotalTrades = () => _getTotalCount(TOTAL_TRADES_COUNT_QUERY_ID)
 
+/**
+ * @deprecated
+ */
 export const getTotalSurplus = async (): Promise<TotalCount> => {
   const queryResut = await getFromDune<{ surplus_type: string, total_surplus_usd: number }>(TOTAL_SURPLUS_COUNT_QUERY_ID)
 


### PR DESCRIPTION
This release:
*  Stops using Dune v0 (it will load the stats from https://raw.githubusercontent.com/cowprotocol/cow-fi/configuration/config/stats.json)
* Fixes the 404 error when you try to follow the link to Dune dashboard

## Change log

c6f8c10 Load stats from config + deprecate Dune v0 (#35)
5c6638e Merge branch 'main' into develop
ca132ec update Dune analytics url
3ec835f Replaced cowswap.exchange with swap.cow.fi (#30)