### PR TITLE
Refactor menus: header / footer

### DIFF
--- a/components/CustomLink.tsx
+++ b/components/CustomLink.tsx
@@ -4,7 +4,7 @@ type CustomLinkType = 'internal' | 'external'| 'external_untrusted'
 
 export interface CustomLinkProps {
   url: string
-  title: string, // TODO: label
+  label: string, // TODO: label
   type?: CustomLinkType
   onClick?: () => void
 }
@@ -28,7 +28,7 @@ function getAnchorRel(type?: CustomLinkType): { target?: string, rel?: string } 
 }
 
 export function CustomLink(props: CustomLinkProps) {
-  const { url, title, type='internal', onClick } = props
+  const { url, label: title, type='internal', onClick } = props
   const { rel, target } = getAnchorRel(type)
   return (
     <Link href={url}>

--- a/components/CustomLink.tsx
+++ b/components/CustomLink.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+
+type CustomLinkType = 'internal' | 'external'| 'external_untrusted'
+
+export interface CustomLinkProps {
+  url: string
+  title: string, // TODO: label
+  type?: CustomLinkType
+  onClick?: () => void
+}
+
+function getAnchorRel(type?: CustomLinkType): { target?: string, rel?: string } {
+  switch (type) {
+    case 'external_untrusted':
+      return {
+        target: '_blank',
+        rel: 'noopener noreferrer nofollow'
+      }
+
+    case 'external':
+      return {
+        target: '_blank',
+        rel: 'noopener'
+      }
+  }
+
+  return {}
+}
+
+export function CustomLink(props: CustomLinkProps) {
+  const { url, title, type='internal', onClick } = props
+  const { rel, target } = getAnchorRel(type)
+  return (
+    <Link href={url}>
+      <a 
+        target={target} 
+        rel={rel}
+        onClick={onClick}>
+          {title}
+      </a>
+    </Link>
+  )
+}

--- a/components/Layout/Content.tsx
+++ b/components/Layout/Content.tsx
@@ -1,11 +1,8 @@
 import styled from 'styled-components';
 import { PropsWithChildren } from 'react'
 
-import { siteConfig } from 'const/meta'
-import { mainMenu, footerMenu } from '../../const/menu'
 import Header from 'components/Layout/Header'
 import Footer from 'components/Layout/Footer'
-import { Color, Font, Media } from 'const/styles/variables'
 import { Content } from 'const/styles/pages/content'
 
 export type LayoutProps = PropsWithChildren<{
@@ -26,9 +23,9 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <Wrapper>
-        <Header menu={mainMenu} siteConfig={siteConfig} />
+        <Header />
         <Content>{children ? children : 'No content found'}</Content>
-        <Footer menu={footerMenu} siteConfig={siteConfig} />
+        <Footer />
       </Wrapper>
     </>
   )

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -152,7 +152,7 @@ const CopyrightLinks = styled.ol`
 function FooterMenu() {
   return (
     <MenuSection>
-      { FOOTER_LINK_GROUPS.map(({ title, links }, index) => (
+      { FOOTER_LINK_GROUPS.map(({ label: title, links }, index) => (
         <MenuWrapper key={index}>
           <b>{title}</b>
           <Menu>

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -2,8 +2,12 @@ import styled from 'styled-components';
 import Link from 'next/link'
 import { Color, Font, Media } from 'const/styles/variables'
 import SocialList from 'components/SocialList'
+import { CustomLink } from '../CustomLink';
+import { FooterLinkGroup, FOOTER_LINK_GROUPS } from '@/const/menu';
+import { CONFIG } from '@/const/meta';
 
 const LogoImage = 'images/logo-light.svg'
+const CURRENT_YEAR = new Date().getFullYear()
 
 const Wrapper = styled.footer`
   display: flex;
@@ -145,41 +149,45 @@ const CopyrightLinks = styled.ol`
   }
 `
 
-export default function Footer({ siteConfig, menu }) {
-  const { social } = siteConfig
-  const currentYear = new Date().getFullYear()
-
+function FooterMenu() {
   return (
-    <Wrapper>
-
-      {menu.length > 0 && <MenuSection>{menu.map(({ id, title, links }) => (
-        <MenuWrapper key={id}>
+    <MenuSection>
+      { FOOTER_LINK_GROUPS.map(({ title, links }, index) => (
+        <MenuWrapper key={index}>
           <b>{title}</b>
           <Menu>
-            {links.map(({ title, url, target }, index) =>
+            {links.map((link, index) =>
               <li key={index}>
-                <Link href={url}>
-                  <a target={target}>
-                    {title}
-                  </a>
-                </Link>
+                <CustomLink {...link} />
               </li>
             )}
           </Menu>
         </MenuWrapper>
-      ))}</MenuSection>}
+      ))}
+    </MenuSection>
+  )
+}
 
+function Social() {
+  const { social } = CONFIG    
+  return (
+    <LogoSection>
+      <Link passHref href='/'>
+        <Logo />
+      </Link>
+      <SocialList social={social} labels={false} iconSize={2.8} gap={0.7} innerPadding={1} alignItems={'right'} />
+      <CopyrightLinks>
+        <li>©CoW Protocol - {CURRENT_YEAR}</li>
+      </CopyrightLinks>
+    </LogoSection>
+  )
+}
 
-      <LogoSection>
-        <Link passHref href='/'>
-          <Logo />
-        </Link>
-        <SocialList social={social} labels={false} iconSize={2.8} gap={0.7} innerPadding={1} alignItems={'right'} />
-        <CopyrightLinks>
-          <li>©CoW Protocol - {currentYear}</li>
-        </CopyrightLinks>
-      </LogoSection>
-
+export default function Footer() {
+  return (
+    <Wrapper>
+      <FooterMenu />
+      <Social />
     </Wrapper >
   )
 }

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -7,6 +7,9 @@ import { Defaults, Color, Font, Media } from 'const/styles/variables'
 import { InView } from 'react-intersection-observer'
 import useMediaQuery from 'lib/hooks/useMediaQuery';
 import { useRouter } from 'next/router'
+import { CustomLink as CustomLink } from '../CustomLink';
+import { CONFIG } from '@/const/meta';
+import { HEADER_LINKS } from '@/const/menu';
 
 const LogoImage = 'images/logo.svg'
 const LogoLightImage = 'images/logo-light.svg'
@@ -261,8 +264,8 @@ const Logo = styled.div<{isHome?: boolean}>`
   }
 `
 
-export default function Header({ siteConfig, menu }) {
-  const swapURL = siteConfig.url.swap
+export default function Header() {
+  const swapURL = CONFIG.url.swap
   const isTouch = useMediaQuery(`(max-width: ${Media.mediumEnd})`);
   const [menuVisible, setIsMenuVisible] = useState(false)
   const toggleBodyScroll = () => {
@@ -292,9 +295,9 @@ export default function Header({ siteConfig, menu }) {
             </Link>
 
             <Menu className={menuVisible ? 'visible' : ""} isHome={isHome}>
-              {menu.map(({ id, title, url, target, rel }) => (
-                <li key={id}>
-                  <a onClick={handleClick} href={url} target={target} rel={rel}>{title}</a>
+              {HEADER_LINKS.map((link, index) => (
+                <li key={index}>
+                  <CustomLink {...link} />
                 </li>
               ))}
               <CloseIcon onClick={handleClick} />

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { PropsWithChildren } from 'react'
 
-import { siteConfig } from 'const/meta'
-import { mainMenu, footerMenu } from '../../const/menu'
+import { CONFIG } from 'const/meta'
+import { HEADER_LINKS, FOOTER_LINK_GROUPS } from '../../const/menu'
 import Header from 'components/Layout/Header'
 import Footer from 'components/Layout/Footer'
 
@@ -33,9 +33,9 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <Wrapper>
-        <Header menu={mainMenu} siteConfig={siteConfig} />
+        <Header menu={HEADER_LINKS} siteConfig={CONFIG} />
         <Content>{children ? children : 'No content found'}</Content>
-        <Footer menu={footerMenu} siteConfig={siteConfig} />
+        <Footer menu={FOOTER_LINK_GROUPS} siteConfig={CONFIG} />
       </Wrapper>
     </>
   )

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,17 +1,7 @@
 import styled from 'styled-components';
 import { PropsWithChildren } from 'react'
-
-import { CONFIG } from 'const/meta'
-import { HEADER_LINKS, FOOTER_LINK_GROUPS } from '../../const/menu'
 import Header from 'components/Layout/Header'
 import Footer from 'components/Layout/Footer'
-
-export type LayoutProps = PropsWithChildren<{
-  siteConfigData?: any // needs fix
-  metrics?: any // needs fix
-  mainMenuData?: any // needs fix
-  footerMenuData?: any // needs fix
-}>
 
 const Wrapper = styled.div`
   margin: 0 auto;
@@ -20,7 +10,7 @@ const Wrapper = styled.div`
   width: 100%;
 `
 
-const Content = styled.main`
+const FullWidthContent = styled.main`
   margin: -10.4rem auto 0;
   padding: 0;
   box-sizing: border-box;
@@ -29,13 +19,20 @@ const Content = styled.main`
   flex-flow: column wrap;
 `
 
-export default function Layout({ children }: LayoutProps) {
+import { Content } from 'const/styles/pages/content'
+
+type LayoutProps = PropsWithChildren<{ fullWidth?: boolean }>
+
+export default function Layout(props: LayoutProps) {
+  const { children, fullWidth = false } = props
+  const content = children ? children : 'No content found'
+  const ContentComponent = fullWidth ? FullWidthContent : Content
   return (
     <>
       <Wrapper>
-        <Header menu={HEADER_LINKS} siteConfig={CONFIG} />
-        <Content>{children ? children : 'No content found'}</Content>
-        <Footer menu={FOOTER_LINK_GROUPS} siteConfig={CONFIG} />
+        <Header />
+        <ContentComponent>{content}</ContentComponent>
+        <Footer />
       </Wrapper>
     </>
   )

--- a/const/api.ts
+++ b/const/api.ts
@@ -1,6 +1,6 @@
-import { siteConfig } from './meta'
+import { CONFIG } from './meta'
 
-export const GET_QUOTE = `curl '${siteConfig.url.api}/api/v1/quote' \
+export const GET_QUOTE = `curl '${CONFIG.url.api}/api/v1/quote' \
 -H 'Content-Type: application/json' \
 -d '{
  "kind": "sell",

--- a/const/batches.ts
+++ b/const/batches.ts
@@ -1,6 +1,6 @@
-import { siteConfig } from '@/const/meta'
+import { CONFIG } from '@/const/meta'
 
-const { url } = siteConfig
+const { url } = CONFIG
 
 export const batches = [
   /*

--- a/const/menu.ts
+++ b/const/menu.ts
@@ -1,61 +1,51 @@
-import { siteConfig } from 'const/meta'
-const {url, social} = siteConfig
+import { CustomLinkProps } from '@/components/CustomLink'
+import { CONFIG } from 'const/meta'
+const {url, social} = CONFIG
 
-export const mainMenu = [
-  // { id: 0, title: 'About', url: '/#about'
-  // items: [
-  //   { id: 0, title: 'How it works', url: '/careers' },
-  //   { id: 1, title: 'Careers', url: '/careers' },
-  //   { id: 2, title: 'How it works', url: '/careers' },
-  //   { id: 3, title: 'Careers', url: '/careers' },
-  // ]
-// },
-  { id: 0, title: 'Developers', url: '/#developers'},
-  { id: 1, title: 'Governance', url: social.forum.url, target: "_blank", rel: "noopener nofollow"},
-  // { id: 0, title: 'Docs', url: url.docs, target: "_blank", rel: "noopener nofollow" },
-  // { id: 1, title: 'Developers', url: '/#developers'},
-  // { id: 1, title: 'About', url: '/#about' },
-  // { id: 2, title: 'Community', url: social.discord.url, target: "_blank", rel: "noopener nofollow" },
-  // { id: 3, title: 'Analytics', url: url.analytics, target: "_blank", rel: "noopener nofollow" },
-  { id: 2, title: 'Careers', url: '/careers' },
+export interface FooterLinkGroup {
+  title: string,
+  links: CustomLinkProps[]
+}
+
+export const HEADER_LINKS: CustomLinkProps[] = [
+  { title: 'Developers', url: '/#developers'},
+  { title: 'Governance', url: social.forum.url, type: 'external_untrusted'},
+  { title: 'Careers', url: '/careers' },
 ]
 
-export const footerMenu = [
+export const FOOTER_LINK_GROUPS: FooterLinkGroup[] = [
   {
-    id: 0, title: 'CoW Protocol', links: [      
-      { title: 'Governance', url: 'https://snapshot.org/#/cow.eth', target: "_blank"  },
-      { title: 'Forum', url: 'https://forum.cow.fi', target: "_blank"  },
-      { title: 'Blog', url: 'https://medium.com/@cow-protocol', target: "_blank"  },
-      { title: 'Analytics', url: url.analytics, target: "_blank" },
+    title: 'CoW Protocol', links: [      
+      { title: 'Governance', url: 'https://snapshot.org/#/cow.eth', type: 'external'  },
+      { title: 'Forum', url: 'https://forum.cow.fi', type: 'external'  },
+      { title: 'Blog', url: 'https://medium.com/@cow-protocol', type: 'external'  },
+      { title: 'Analytics', url: url.analytics, type: 'external' },
       { title: 'Careers', url: '/careers' },
-      { title: 'Grants', url: url.grants, target: "_blank" },
-
-      // { title: 'Sitemap', url: '/' },
+      { title: 'Grants', url: url.grants, type: 'external' },
+      { title: 'Explorer', url: url.explorer, type: 'external' },
     ]
   },
   {
-    id: 0, title: 'About', links: [
+    title: 'About', links: [
       { title: 'CoW Protocol', url: '/#about' },
-      { title: 'CoW Swap', url: 'https://swap.cow.fi/#/about', target: "_blank" },
-      { title: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', target: "_blank" },
-    
-      // { title: 'Sitemap', url: '/' },
+      { title: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external' },
+      { title: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external' },
     ]
   },
   {
-    id: 1, title: 'Developers', links: [
-      { title: 'Documentation', url: url.docs, target: "_blank" },
-      { title: 'API Documentation', url: url.apiDocs, target: "_blank" },
-      { title: 'GitHub', url: social.github.url, target: "_blank" },
-      { title: 'Audit 1: G0 Group', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/GnosisProtocolV2May2021.pdf' },
-      { title: 'Audit 2: Hacken', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/%5BCowswap_10122021%5DSCAudit_Report_2.pdf' },
+    title: 'Developers', links: [
+      { title: 'Documentation', url: url.docs, type: 'external' },
+      { title: 'API Documentation', url: url.apiDocs, type: 'external' },
+      { title: 'GitHub', url: social.github.url, type: 'external' },
+      { title: 'Audit 1: G0 Group', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/GnosisProtocolV2May2021.pdf', type: 'external_untrusted' },
+      { title: 'Audit 2: Hacken', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/%5BCowswap_10122021%5DSCAudit_Report_2.pdf', type: 'external_untrusted' },      
       // { title: 'Bug bounty', url: '/' },
     ]
   },
   {
-    id: 2, title: 'Support', links: [
-      { title: 'Discord', url: social.discord.url, target: "_blank" },
-      { title: 'Security portal', url: url.securityPortal, target: "_blank" },
+    title: 'Support', links: [
+      { title: 'Discord', url: social.discord.url, type: 'external_untrusted' },
+      { title: 'Security portal', url: url.securityPortal, type: 'external_untrusted' },
       // TODO:
       // { title: 'Terms of service', url: '/' },
       // { title: 'Privacy Policy', url: '/' },

--- a/const/menu.ts
+++ b/const/menu.ts
@@ -3,49 +3,49 @@ import { CONFIG } from 'const/meta'
 const {url, social} = CONFIG
 
 export interface FooterLinkGroup {
-  title: string,
+  label: string,
   links: CustomLinkProps[]
 }
 
 export const HEADER_LINKS: CustomLinkProps[] = [
-  { title: 'Developers', url: '/#developers'},
-  { title: 'Governance', url: social.forum.url, type: 'external_untrusted'},
-  { title: 'Careers', url: '/careers' },
+  { label: 'Developers', url: '/#developers'},
+  { label: 'Governance', url: social.forum.url, type: 'external_untrusted'},
+  { label: 'Careers', url: '/careers' },
 ]
 
 export const FOOTER_LINK_GROUPS: FooterLinkGroup[] = [
   {
-    title: 'CoW Protocol', links: [      
-      { title: 'Governance', url: 'https://snapshot.org/#/cow.eth', type: 'external'  },
-      { title: 'Forum', url: 'https://forum.cow.fi', type: 'external'  },
-      { title: 'Blog', url: 'https://medium.com/@cow-protocol', type: 'external'  },
-      { title: 'Analytics', url: url.analytics, type: 'external' },
-      { title: 'Careers', url: '/careers' },
-      { title: 'Grants', url: url.grants, type: 'external' },
-      { title: 'Explorer', url: url.explorer, type: 'external' },
+    label: 'CoW Protocol', links: [      
+      { label: 'Governance', url: 'https://snapshot.org/#/cow.eth', type: 'external'  },
+      { label: 'Forum', url: 'https://forum.cow.fi', type: 'external'  },
+      { label: 'Blog', url: 'https://medium.com/@cow-protocol', type: 'external'  },
+      { label: 'Analytics', url: url.analytics, type: 'external' },
+      { label: 'Careers', url: '/careers' },
+      { label: 'Grants', url: url.grants, type: 'external' },
+      { label: 'Explorer', url: url.explorer, type: 'external' },
     ]
   },
   {
-    title: 'About', links: [
-      { title: 'CoW Protocol', url: '/#about' },
-      { title: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external' },
-      { title: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external' },
+    label: 'About', links: [
+      { label: 'CoW Protocol', url: '/#about' },
+      { label: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external' },
+      { label: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external' },
     ]
   },
   {
-    title: 'Developers', links: [
-      { title: 'Documentation', url: url.docs, type: 'external' },
-      { title: 'API Documentation', url: url.apiDocs, type: 'external' },
-      { title: 'GitHub', url: social.github.url, type: 'external' },
-      { title: 'Audit 1: G0 Group', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/GnosisProtocolV2May2021.pdf', type: 'external_untrusted' },
-      { title: 'Audit 2: Hacken', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/%5BCowswap_10122021%5DSCAudit_Report_2.pdf', type: 'external_untrusted' },      
+    label: 'Developers', links: [
+      { label: 'Documentation', url: url.docs, type: 'external' },
+      { label: 'API Documentation', url: url.apiDocs, type: 'external' },
+      { label: 'GitHub', url: social.github.url, type: 'external' },
+      { label: 'Audit 1: G0 Group', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/GnosisProtocolV2May2021.pdf', type: 'external_untrusted' },
+      { label: 'Audit 2: Hacken', url: 'https://github.com/gnosis/gp-v2-contracts/raw/main/audits/%5BCowswap_10122021%5DSCAudit_Report_2.pdf', type: 'external_untrusted' },      
       // { title: 'Bug bounty', url: '/' },
     ]
   },
   {
-    title: 'Support', links: [
-      { title: 'Discord', url: social.discord.url, type: 'external_untrusted' },
-      { title: 'Security portal', url: url.securityPortal, type: 'external_untrusted' },
+    label: 'Support', links: [
+      { label: 'Discord', url: social.discord.url, type: 'external_untrusted' },
+      { label: 'Security portal', url: url.securityPortal, type: 'external_untrusted' },
       // TODO:
       // { title: 'Terms of service', url: '/' },
       // { title: 'Privacy Policy', url: '/' },

--- a/const/meta.ts
+++ b/const/meta.ts
@@ -1,6 +1,6 @@
 const API_BASE_URL = "https://api.cow.fi"
 
-export const siteConfig = {
+export const CONFIG = {
   title: 'CoW Protocol',
   description: 'CoW Protocol finds the lowest prices from all decentralized exchanges and DEX aggregators & saves you more with p2p trading and protection from MEV ',
   descriptionShort: 'The smartest way to trade cryptocurrencies',

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,9 +1,9 @@
 import Head from 'next/head'
 import Link from 'next/link'
-import Content from 'components/Layout/Content'
 import { GetStaticProps } from 'next'
 import { CONFIG } from '@/const/meta'
 import { Title, Section } from 'const/styles/pages/content'
+import Layout from '@/components/Layout'
 
 // pages/404.js
 export default function Custom404({ siteConfigData }) {
@@ -14,12 +14,12 @@ export default function Custom404({ siteConfigData }) {
     <Head>
       <title>Page Not Found (404) - {title}</title>
     </Head>
-    <Content>
+    <Layout>
       <Section>
         <Title>404 - Page Not Found</Title>
         <p>This page could not be found. Please go back to the <Link href="/">home page.</Link></p>
       </Section>
-    </Content>
+    </Layout>
     </>
   )
 }

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 import Content from 'components/Layout/Content'
 import { GetStaticProps } from 'next'
-import { siteConfig } from '@/const/meta'
+import { CONFIG } from '@/const/meta'
 import { Title, Section } from 'const/styles/pages/content'
 
 // pages/404.js
@@ -25,7 +25,7 @@ export default function Custom404({ siteConfigData }) {
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-  const siteConfigData = siteConfig
+  const siteConfigData = CONFIG
 
   return {
     props: { siteConfigData },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,7 @@ import { AppProps } from 'next/app'
 import GlobalStyles from 'const/styles/global'
 import Head from 'next/head'
 
-import { siteConfig } from '@/const/meta'
+import { CONFIG } from '@/const/meta'
 import { Analytics } from '@/components/Analytics'
 
 // import { i18n } from '@lingui/core'
@@ -40,7 +40,7 @@ export default function App(props: AppProps) {
   return (
     <>
       <Head>
-        <meta name="description" content={siteConfig.description} />
+        <meta name="description" content={CONFIG.description} />
         <meta name="theme-color" media="(prefers-color-scheme: light)" content="black" />
         <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
 
@@ -49,16 +49,16 @@ export default function App(props: AppProps) {
         <link rel="apple-touch-icon" sizes="512x512" href="/favicon.png" />
 
         <meta property="og:type" content="website" />
-        <meta property="og:title" content={siteConfig.title} />
+        <meta property="og:title" content={CONFIG.title} />
 
-        <meta property="og:description" content={siteConfig.description} />
-        <meta property="og:image" content={siteConfig.url.root + "/images/og-meta-cowprotocol.png"} />
-        <meta property="og:url" content={siteConfig.url.root} /> {/* TODO: Add URL */}
+        <meta property="og:description" content={CONFIG.description} />
+        <meta property="og:image" content={CONFIG.url.root + "/images/og-meta-cowprotocol.png"} />
+        <meta property="og:url" content={CONFIG.url.root} /> {/* TODO: Add URL */}
 
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:site" content={siteConfig.social.twitter.account} />
-        <meta name="twitter:title" content={siteConfig.title} />
-        <meta name="twitter:image" content={siteConfig.url.root + "/images/og-meta-cowprotocol.png"} />
+        <meta name="twitter:site" content={CONFIG.social.twitter.account} />
+        <meta name="twitter:title" content={CONFIG.title} />
+        <meta name="twitter:image" content={CONFIG.url.root + "/images/og-meta-cowprotocol.png"} />
         <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1"></meta>
       </Head>
       

--- a/pages/careers.tsx
+++ b/pages/careers.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head'
 import { useState } from 'react'
 import { GetStaticProps } from 'next'
 import { CONFIG } from '@/const/meta'
-import Content from 'components/Layout/Content'
+import Layout from '@/components/Layout'
 import { Section, Title, SubTitle, TitleSmall, LinkContainer } from 'const/styles/pages/content'
 import { DropDown, ExternalLink } from '@/const/styles/global'
 import SVG from 'react-inlinesvg'
@@ -42,7 +42,7 @@ export default function Jobs({ jobsData, siteConfigData }) {
     <Head>
       <title>Careers - {title}</title>
     </Head>
-    <Content>
+    <Layout>
       <Section>
         <Title>Want to build the future of decentralized trading?</Title>
         <SubTitle>We are an ambitious, fast growing and international team working at the forefront of DeFi. We believe that we can make markets both more efficient and fair, by building the ultimate batch auction settlement layer across EVM compatible blockchains.</SubTitle>
@@ -91,7 +91,7 @@ export default function Jobs({ jobsData, siteConfigData }) {
         <p>{jobsCount < 1 && 'Currently there are no open positions. Convinced you can contribute to Cow Protocol?'}{jobsCount > 0 && "Can't find the position you're looking for?"} <ExternalLink href={discordURL} target="_blank" rel="noopener nofollow">Get in touch</ExternalLink></p>
       </Section>
 
-    </Content>
+    </Layout>
     </>
   )
 }

--- a/pages/careers.tsx
+++ b/pages/careers.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import { useState } from 'react'
 import { GetStaticProps } from 'next'
-import { siteConfig } from '@/const/meta'
+import { CONFIG } from '@/const/meta'
 import Content from 'components/Layout/Content'
 import { Section, Title, SubTitle, TitleSmall, LinkContainer } from 'const/styles/pages/content'
 import { DropDown, ExternalLink } from '@/const/styles/global'
@@ -9,7 +9,7 @@ import SVG from 'react-inlinesvg'
 
 async function getJobs() {
   const jobsData = {}
-  const { api } = siteConfig.greenhouse
+  const { api } = CONFIG.greenhouse
 
   try {
     const response = await fetch(api)
@@ -27,7 +27,7 @@ async function getJobs() {
 
 export default function Jobs({ jobsData, siteConfigData }) {
   const { title } = siteConfigData
-  const discordURL = siteConfig.social.discord.url
+  const discordURL = CONFIG.social.discord.url
   const [department, setDepartment] = useState('All')
   const handleDepartmentChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setDepartment(e.target.value)
@@ -98,7 +98,7 @@ export default function Jobs({ jobsData, siteConfigData }) {
 
 export const getStaticProps: GetStaticProps = async () => {
   const jobsData = await getJobs()
-  const siteConfigData = siteConfig
+  const siteConfigData = CONFIG
 
   return {
     props: { jobsData, siteConfigData },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home({ metricsData, siteConfigData }: HomeProps) {
   // }
 
   return (
-    <Layout>
+    <Layout fullWidth={true}>
 
       <Head>
         <title>{title} - {descriptionShort}</title>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import { useRef } from 'react'
 // import { default as dark } from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
 
 // import { ExternalLink } from '@/const/styles/global'
-import { siteConfig } from '@/const/meta'
+import { CONFIG } from '@/const/meta'
 import { Color } from 'const/styles/variables'
 
 import Layout from '@/components/Layout'
@@ -36,7 +36,7 @@ interface MetricsData {
 }
 interface HomeProps {
   metricsData: MetricsData
-  siteConfigData: typeof siteConfig
+  siteConfigData: typeof CONFIG
 }
 
 export default function Home({ metricsData, siteConfigData }: HomeProps) {
@@ -278,8 +278,8 @@ export default function Home({ metricsData, siteConfigData }: HomeProps) {
 
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
-  const siteConfigData = siteConfig
-  const { social } = siteConfig
+  const siteConfigData = CONFIG
+  const { social } = CONFIG
   const { volumeUsd, volumeEth } = await cowSdk.cowSubgraphApi.getTotals()
   const { surplus, totalTrades, lastModified } = await getCowStats()
 


### PR DESCRIPTION
Follow up on #49 

Mainly to address some changes I wanted to do:
- Add `rel` to some links in the menu of header and footer
- Improve the types of the links 

## Capitalize some constant
I just capitalized the constants, like now the `siteConfig` is `CONFIG`. Same for `FOOTER_LINK_GROUPS` and `HEADER_LINKS`

## Don't pass the constants as props
Also, now the constants are imported closer to the place they are used. This way we don't need to pass them down to the components. This makes the Header and Footer take no parameters.  (see https://github.com/cowprotocol/cow-fi/pull/50/files#diff-0b598fca45880adfbb94d70345ea5803536ced16ba22ab3ceb48499ba2d5634eR26)

## Add types to the links/urls configuration
The links had no type, so they were passed down with type `any` which is not too good
https://github.com/cowprotocol/cow-fi/pull/50/files#diff-ba73eb06f4599ba2305489389db4c3ad95af89a914eeea7d49d6fcc3b20c8194R5

## Added `rel` logic
CONTEXT: https://pointjupiter.com/what-noopener-noreferrer-nofollow-explained/

My understanding is that we want 3 types of links in our app: 
- internal: just points to somewhere in the app
- external: points to one of our other apps
- external and untrusted: points to some URL we don't necessarily trust

For external links, we want for sure  `noopener` since it's and important security good practice

However, for our own sites I think we don't want to add `noreferrer` because this way we allow ourselves to see the traffic that is coming from cow.fi to swap.cow.fi (for example).

The same for `nofollow`, I understand that adding it tells the search engines that web has nothing to do with us, and it wouldn't give them credit. So I would think for reputable links, we shouldn't add it. 

This is how the map https://github.com/cowprotocol/cow-fi/pull/50/files#diff-3037904c48b7afafd14441a88ea0bebcafc38051e0ac17e1bf84d15d1aee9285R13


## Refactor the link creation
The to menus had very similar link creation, and I needed the `rel` logic to be similar, so I just moved it its own component. 


## Refactor Container / Layout components

I turns out we had a bit of duplication around the `Content` and `Layout` component. 

I found they were almost the same thing! Layout was being used only for the home, and Content for content pages.

What I did Is to use always Layout, and pass a `fullWidth=true` prop to it for the non-content pages --> only the home

See commit:
https://github.com/cowprotocol/cow-fi/pull/50/commits/9834096c4d0c65f41166fd846dd9722fba8c9f6b


## Not included
I think this project needs:
- enable eslint and prettify 
- Make the lining and TS more restrictive, right now it doesn't complain if you don't declare types

