### PR TITLE
🐛 Fix margin on SocialList images if no label is present

### DIFF
--- a/components/SocialList.tsx
+++ b/components/SocialList.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { transparentize } from 'polished'
 import { Color, Font, Media } from 'const/styles/variables'
 
-const Wrapper = styled.ol<Pick<SocialListProps, "iconSize" | "gap" | "innerPadding" | "alignItems">>`
+const Wrapper = styled.ol<Pick<SocialListProps, "iconSize" | "gap" | "innerPadding" | "alignItems" | "labels">>`
   display: flex;
   justify-content: ${({ alignItems }) => (alignItems === 'left') ? 'flex-start' : (alignItems === 'right') ? 'flex-end' : 'center'};
   align-items: center;
@@ -51,7 +51,7 @@ const Wrapper = styled.ol<Pick<SocialListProps, "iconSize" | "gap" | "innerPaddi
     width: ${({ iconSize }) => iconSize ? `${iconSize}rem` : '5.8rem'};
     height: ${({ iconSize }) => iconSize ? `${iconSize}rem` : '5.8rem'};
     object-fit: contain;
-    margin: 0 0 1.2rem;
+    margin: ${({ labels }) => labels ? `0 0 1.2rem` : `0`};
   }
 
   > li > a > b {
@@ -72,7 +72,7 @@ interface SocialListProps {
 export default function SocialList({ social, labels = true, iconSize, gap, innerPadding, alignItems }: SocialListProps) {
 
   return (
-    <Wrapper iconSize={iconSize} gap={gap} innerPadding={innerPadding} alignItems={alignItems}>
+    <Wrapper iconSize={iconSize} gap={gap} innerPadding={innerPadding} alignItems={alignItems} labels={labels}>
       {Object.keys(social).map((item, i) =>
         <li key={i}>
           <a href={social[item].url} target="_blank" rel="noopener nofollow noreferrer">


### PR DESCRIPTION
Fix game-breaking critical bug in your UI, literally unplayable right now

### Description

Your `SocialList` always has a bottom margin of 1.2rem, even if the image does not have a label underneath it 🫣😱 

<img width="623" alt="Screenshot 2022-12-04 at 16 05 40" src="https://user-images.githubusercontent.com/2313704/205501815-0420205b-35ef-42fb-8daf-f22ee56a7fc0.png">

