### PR TITLE
Add support for brave analytics

### DIFF
--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -1,9 +1,27 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react'
 import Router from 'next/router'
-import ReactGA from 'react-ga4';
+import ReactGA from 'react-ga4'
 import { isMobile } from 'react-device-detect'
 
-const trackingId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
+const trackingId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS
+
+function initBraveAnalytics() {
+  let params: any = new Proxy(new URLSearchParams(window.location.search), {
+    get: (searchParams, prop) => searchParams.get(prop as string),
+  })
+
+  if (params && params.utm_source) {
+    document.cookie = `source=${params.utm_source};domain=.cow.fi;path=/`
+  }
+
+  if (params && params.utm_medium) {
+    document.cookie = `medium=${params.utm_medium};domain=.cow.fi;path=/`
+  }
+
+  if (params && params.utm_campaign) {
+    document.cookie = `campaign=${params.utm_campaign};domain=.cow.fi;path=/`
+  }
+}
 
 function handleRouteChange(page_path: string) {
   console.log('[Analytics] Page view', page_path)
@@ -23,10 +41,12 @@ function initializeAnalytics() {
     customBrowserType: !isMobile
       ? 'desktop'
       : 'web3' in window || 'ethereum' in window
-        ? 'mobileWeb3'
-        : 'mobileRegular',
+      ? 'mobileWeb3'
+      : 'mobileRegular',
   })
 
+  // Init brave analytics
+  initBraveAnalytics()
 
   // Handle all route changes
   handleRouteChange(Router.pathname)
@@ -34,10 +54,9 @@ function initializeAnalytics() {
 }
 
 export function Analytics() {
-
   // Internal state
   const [analytics, setAnalytics] = useState({
-    isInitialized: false
+    isInitialized: false,
   })
 
   // Use effect is used so the code is only executed client side (not server side)
@@ -47,16 +66,16 @@ export function Analytics() {
     // Initialize Analytics
     if (trackingId && !isInitialized) {
       initializeAnalytics()
-      setAnalytics(prev => ({
+      setAnalytics((prev) => ({
         ...prev,
-        isInitialized: true
+        isInitialized: true,
       }))
     }
 
     return () => {
       // clean up
       if (isInitialized) {
-        Router.events.off('routeChangeComplete', handleRouteChange);
+        Router.events.off('routeChangeComplete', handleRouteChange)
       }
     }
   }, [analytics])

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -2,26 +2,9 @@ import { useState, useEffect } from 'react'
 import Router from 'next/router'
 import ReactGA from 'react-ga4'
 import { isMobile } from 'react-device-detect'
+import { initBraveAnalytics } from 'lib/analytics/brave'
 
 const trackingId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS
-
-function initBraveAnalytics() {
-  let params: any = new Proxy(new URLSearchParams(window.location.search), {
-    get: (searchParams, prop) => searchParams.get(prop as string),
-  })
-
-  if (params && params.utm_source) {
-    document.cookie = `source=${params.utm_source};domain=.cow.fi;path=/`
-  }
-
-  if (params && params.utm_medium) {
-    document.cookie = `medium=${params.utm_medium};domain=.cow.fi;path=/`
-  }
-
-  if (params && params.utm_campaign) {
-    document.cookie = `campaign=${params.utm_campaign};domain=.cow.fi;path=/`
-  }
-}
 
 function handleRouteChange(page_path: string) {
   console.log('[Analytics] Page view', page_path)

--- a/lib/analytics/brave.ts
+++ b/lib/analytics/brave.ts
@@ -1,0 +1,22 @@
+export function initBraveAnalytics() {
+  const params = new URLSearchParams(window.location.search)
+
+  // Put UTM labels from query-string to cookies
+  if (params) {
+    const utm_source = params.get('utm_source')
+    const utm_medium = params.get('utm_medium')
+    const utm_campaign = params.get('utm_campaign')
+
+    if (utm_source) {
+      document.cookie = `source=${utm_source};domain=.cow.fi;path=/`
+    }
+
+    if (utm_medium) {
+      document.cookie = `medium=${utm_medium};domain=.cow.fi;path=/`
+    }
+
+    if (utm_campaign) {
+      document.cookie = `campaign=${utm_campaign};domain=.cow.fi;path=/`
+    }
+  }
+}


### PR DESCRIPTION
# Summary

As requested by operator and marketing team we are adding this to support Brave browser tracking.
This PR adds a method that will be called on initial app load and it will set cookies based on query string parameters.
The expected query-string keys are `utm_source`, `utm_medium` and `utm_campaign`.
The domain is `.cow.fi` so that those cookies will persist also on `swap.cow.fi`

### To test
I'm not sure this can be tested in a PR because the cookies have a domain `.cow.fi` which is correct but it can't be set in a PR because of a different domain on PR.