### PR TITLE
Load data dynamically

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1,10173 +1,9810 @@
 [
-    {
-        "id": "1inch",
-        "symbol": "1inch",
-        "name": "1inch",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x111111111117dc0aa78b770fa6a738034120c302",
-            "near-protocol": "111111111117dc0aa78b770fa6a738034120c302.factory.bridge.near",
-            "binance-smart-chain": "0x111111111117dc0aa78b770fa6a738034120c302",
-            "polygon-pos": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
-            "harmony-shard-0": "0x58f1b044d8308812881a1433d9bbeff99975e70c",
-            "avalanche": "0xd501281565bf7789224523144fe5d98e8b28f267",
-            "energi": "0xdda6205dc3f47e5280eb726613b27374eee9d130"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x111111111117dc0aa78b770fa6a738034120c302"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "111111111117dc0aa78b770fa6a738034120c302.factory.bridge.near"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0x111111111117dc0aa78b770fa6a738034120c302"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0x58f1b044d8308812881a1433d9bbeff99975e70c"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0xd501281565bf7789224523144fe5d98e8b28f267"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0xdda6205dc3f47e5280eb726613b27374eee9d130"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Harmony Ecosystem",
-            "Ethereum Ecosystem",
-            "Near Protocol Ecosystem",
-            "Avalanche Ecosystem",
-            "Polygon Ecosystem",
-            "Number",
-            "BNB Chain Ecosystem",
-            "Automated Market Maker (AMM)",
-            "Decentralized Finance (DeFi)",
-            "Decentralized Exchange (DEX)",
-            "Exchange-based Tokens"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "\"What is 1inch Network?\r\n1inch Network is a decentralized exchange (DEX) aggregator to help users discover the best trade prices for tokens. Instead of swapping tokens from a single liquidity pool of a DEX, 1inch will aggregate across different pools and suggest the most efficient way to trade tokens.\r\n\r\nWhy use 1inch?\r\nIf you are a trader trading large amount of tokens, you may not be aware of all the availability liquidity across different DEXes in order to get the best price quote. Price quote offered by DEX fluctuates according to the liquidity pool at any given time. Also, when you are trading large size, every percentage of savings can be magnified with an optimal trading path. 1inch aims to solve all that in a single user friendly interface.\r\n\r\nWhat is Pathfinder?\r\nPathfinder is the discovery and routing algorithm developed by the 1inch team. It is the algorithm the powers the backend to finding the most efficient route to swap a token. For example, if a user wants to sell ETH for WBTC, Pathfinder will explore all DEXes such as Uniswap, Curve, Balancer, DODO, Sushiswap, and more. The result is a recommended route that optimizes fees and liquidity in order to give users the best rate. Users no longer need to check each individual services in order to find the best price.\r\n\r\nWho are the creators of 1inch?\r\n1inch was founded by Sergej Kunz and Anton Bukov. The idea for 1inch was developed at a hackathon in just over 60 hours at New York City. Fast forward today, it is one of the fastest growing DeFi product.\""
-        },
-        "links": {
-            "homepage": [
-                "https://1inch.io/",
-                "https://app.1inch.io/",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x111111111117dc0aa78b770fa6a738034120c302",
-                "https://ethplorer.io/address/0x111111111117dc0aa78b770fa6a738034120c302",
-                "https://bscscan.com/token/0x111111111117dc0aa78b770fa6a738034120c302",
-                "https://polygonscan.com/token/0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
-                "https://snowtrace.io/token/0xd501281565bf7789224523144fe5d98e8b28f267",
-                "https://avascan.info/blockchain/c/address/0xd501281565bf7789224523144fe5d98e8b28f267/token",
-                "https://explorer.energi.network/token/0xdda6205dc3f47e5280eb726613b27374eee9d130",
-                "https://nearblocks.io/token/111111111117dc0aa78b770fa6a738034120c302.factory.bridge.near",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://www.youtube.com/channel/UCk0nvK4bHpteQXZKv7lkq5w",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/1inch",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://blog.1inch.io/",
-                ""
-            ],
-            "twitter_screen_name": "1inch",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "OneInchNetwork",
-            "subreddit_url": "https://www.reddit.com/r/1inch/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/1inch"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
-            "small": "https://assets.coingecko.com/coins/images/13469/small/1inch-token.png?1608803028",
-            "large": "https://assets.coingecko.com/coins/images/13469/large/1inch-token.png?1608803028"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x111111111117dc0aa78b770fa6a738034120c302",
-        "sentiment_votes_up_percentage": 83.33,
-        "sentiment_votes_down_percentage": 16.67,
-        "watchlist_portfolio_users": 104996,
-        "market_cap_rank": 110,
-        "coingecko_rank": 266,
-        "coingecko_score": 33.994,
-        "developer_score": 0,
-        "community_score": 38.915,
-        "liquidity_score": 53.381,
-        "public_interest_score": 0.062,
-        "market_data": {
-            "current_price": {
-                "usd": 0.32295
-            },
-            "total_value_locked": {
-                "usd": 5580871
-            },
-            "mcap_to_tvl_ratio": 54.41,
-            "fdv_to_tvl_ratio": 86.8,
-            "roi": null,
-            "ath": {
-                "usd": 8.65
-            },
-            "ath_change_percentage": {
-                "usd": -96.28012
-            },
-            "ath_date": {
-                "usd": "2021-10-27T08:24:54.808Z"
-            },
-            "atl": {
-                "usd": 0.254171
-            },
-            "atl_change_percentage": {
-                "usd": 26.61929
-            },
-            "atl_date": {
-                "usd": "2023-06-15T17:41:38.825Z"
-            },
-            "market_cap": {
-                "usd": 303669608
-            },
-            "market_cap_rank": 110,
-            "fully_diluted_valuation": {
-                "usd": 484425719
-            },
-            "total_volume": {
-                "usd": 12016373
-            },
-            "high_24h": {
-                "usd": 0.331651
-            },
-            "low_24h": {
-                "usd": 0.31502
-            },
-            "price_change_24h": -0.003475546951717,
-            "price_change_percentage_24h": -1.06473,
-            "price_change_percentage_7d": 16.4549,
-            "price_change_percentage_14d": 18.21083,
-            "price_change_percentage_30d": -19.67534,
-            "price_change_percentage_60d": -33.61626,
-            "price_change_percentage_200d": -28.44081,
-            "price_change_percentage_1y": -55.36706,
-            "market_cap_change_24h": -831208.35993,
-            "market_cap_change_percentage_24h": -0.27297,
-            "price_change_24h_in_currency": {
-                "usd": -0.003475546951716813
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.13059
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -1.06473
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 16.4549
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 18.21083
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -19.67534
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -33.61626
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -28.44081
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -55.36706
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -831208.3599294424
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.27297
-            },
-            "total_supply": 1500000000,
-            "max_supply": 1500000000,
-            "circulating_supply": 940297746.533992,
-            "last_updated": "2023-06-27T11:39:55.691Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:39:55.691Z"
+  {
+    "id": "1inch",
+    "symbol": "1inch",
+    "name": "1inch",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x111111111117dc0aa78b770fa6a738034120c302",
+      "near-protocol": "111111111117dc0aa78b770fa6a738034120c302.factory.bridge.near",
+      "binance-smart-chain": "0x111111111117dc0aa78b770fa6a738034120c302",
+      "polygon-pos": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
+      "harmony-shard-0": "0x58f1b044d8308812881a1433d9bbeff99975e70c",
+      "avalanche": "0xd501281565bf7789224523144fe5d98e8b28f267",
+      "energi": "0xdda6205dc3f47e5280eb726613b27374eee9d130"
     },
-    {
-        "id": "aave",
-        "symbol": "aave",
-        "name": "Aave",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
-            "near-protocol": "7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.factory.bridge.near",
-            "binance-smart-chain": "0xfb6115445bff7b52feb98650c87f44907e58f802",
-            "huobi-token": "0x202b4936fe1a82a4965220860ae46d7d3939bb25",
-            "polygon-pos": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
-            "fantom": "0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b",
-            "harmony-shard-0": "0xcf323aad9e522b93f11c352caa519ad0e14eb40f",
-            "avalanche": "0x63a72806098bd3d9520cc43356dd78afe5d386d9",
-            "sora": "0x0091bd8d8295b25cab5a7b8b0e44498e678cfc15d872ede3215f7d4c7635ba36",
-            "energi": "0xa7f2f790355e0c32cab03f92f6eb7f488e6f049a",
-            "optimistic-ethereum": "0x76fb31fb4af56892a25e32cfc43de717950c9278"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.factory.bridge.near"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xfb6115445bff7b52feb98650c87f44907e58f802"
-            },
-            "huobi-token": {
-                "decimal_place": 18,
-                "contract_address": "0x202b4936fe1a82a4965220860ae46d7d3939bb25"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0xcf323aad9e522b93f11c352caa519ad0e14eb40f"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0x63a72806098bd3d9520cc43356dd78afe5d386d9"
-            },
-            "sora": {
-                "decimal_place": 18,
-                "contract_address": "0x0091bd8d8295b25cab5a7b8b0e44498e678cfc15d872ede3215f7d4c7635ba36"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0xa7f2f790355e0c32cab03f92f6eb7f488e6f049a"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x76fb31fb4af56892a25e32cfc43de717950c9278"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Harmony Ecosystem",
-            "Optimism Ecosystem",
-            "Ethereum Ecosystem",
-            "BNB Chain Ecosystem",
-            "Fantom Ecosystem",
-            "Avalanche Ecosystem",
-            "Polygon Ecosystem",
-            "Near Protocol Ecosystem",
-            "Lending/Borrowing",
-            "Governance",
-            "Yield Farming",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Aave is a decentralized money market protocol where users can lend and borrow cryptocurrency across 20 different assets as collateral. The protocol has a native token called AAVE, which is also a governance token that lets the community decide the direction of the protocol in a collective manner. Lenders can earn interest by providing liquidity to the market, while borrowers can borrow by collateralizing their cryptoassets to take out loans from the liquidity pools.\r\n\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://app.aave.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
-                "https://ethplorer.io/address/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
-                "https://hecoinfo.com/token/0x202b4936fe1a82a4965220860ae46d7d3939bb25",
-                "https://polygonscan.com/token/0xd6df932a45c0f255f85145f286ea0b292b21c90b",
-                "https://snowtrace.io/token/0x63a72806098bd3d9520cc43356dd78afe5d386d9",
-                "https://nearblocks.io/token/7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.factory.bridge.near",
-                "https://ftmscan.com/token/0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b",
-                "https://scan.meter.io/address/0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b",
-                "https://optimistic.etherscan.io/token/0x76fb31fb4af56892a25e32cfc43de717950c9278",
-                "https://avascan.info/blockchain/c/address/0x63a72806098bd3d9520cc43356dd78afe5d386d9/token"
-            ],
-            "official_forum_url": [
-                "https://www.instagram.com/aave.aave/",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://aave.com/discord",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "AaveAave",
-            "facebook_username": "AaveCom",
-            "bitcointalk_thread_identifier": 2090735,
-            "telegram_channel_identifier": "Aavesome",
-            "subreddit_url": "https://www.reddit.com/r/Aave_Official",
-            "repos_url": {
-                "github": [
-                    "https://github.com/aave/aave-protocol"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
-            "small": "https://assets.coingecko.com/coins/images/12645/small/AAVE.png?1601374110",
-            "large": "https://assets.coingecko.com/coins/images/12645/large/AAVE.png?1601374110"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
-        "sentiment_votes_up_percentage": 87.1,
-        "sentiment_votes_down_percentage": 12.9,
-        "watchlist_portfolio_users": 154543,
-        "market_cap_rank": 47,
-        "coingecko_rank": 70,
-        "coingecko_score": 48.535,
-        "developer_score": 47.114,
-        "community_score": 40.229,
-        "liquidity_score": 61.436,
-        "public_interest_score": 0.106,
-        "market_data": {
-            "current_price": {
-                "usd": 64.38
-            },
-            "total_value_locked": {
-                "usd": 3748644722
-            },
-            "mcap_to_tvl_ratio": 0.25,
-            "fdv_to_tvl_ratio": 0.27,
-            "roi": null,
-            "ath": {
-                "usd": 661.69
-            },
-            "ath_change_percentage": {
-                "usd": -90.26519
-            },
-            "ath_date": {
-                "usd": "2021-05-18T21:19:59.514Z"
-            },
-            "atl": {
-                "usd": 26.02
-            },
-            "atl_change_percentage": {
-                "usd": 147.52674
-            },
-            "atl_date": {
-                "usd": "2020-11-05T09:20:11.928Z"
-            },
-            "market_cap": {
-                "usd": 929560818
-            },
-            "market_cap_rank": 47,
-            "fully_diluted_valuation": {
-                "usd": 1030091159
-            },
-            "total_volume": {
-                "usd": 118909644
-            },
-            "high_24h": {
-                "usd": 66.55
-            },
-            "low_24h": {
-                "usd": 62.85
-            },
-            "price_change_24h": -0.9763602100676,
-            "price_change_percentage_24h": -1.49389,
-            "price_change_percentage_7d": 25.17191,
-            "price_change_percentage_14d": 17.70663,
-            "price_change_percentage_30d": -3.6092,
-            "price_change_percentage_60d": -9.72873,
-            "price_change_percentage_200d": 2.62537,
-            "price_change_percentage_1y": -4.72615,
-            "market_cap_change_24h": -14071919.908473,
-            "market_cap_change_percentage_24h": -1.49125,
-            "price_change_24h_in_currency": {
-                "usd": -0.976360210067611
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.45888
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -1.49389
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 25.17191
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 17.70663
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -3.6092
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -9.72873
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 2.62537
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -4.72615
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -14071919.908472657
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.49125
-            },
-            "total_supply": 16000000,
-            "max_supply": 16000000,
-            "circulating_supply": 14438501.846501943,
-            "last_updated": "2023-06-27T11:39:55.724Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 15890,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:39:55.724Z"
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x111111111117dc0aa78b770fa6a738034120c302"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "111111111117dc0aa78b770fa6a738034120c302.factory.bridge.near"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0x111111111117dc0aa78b770fa6a738034120c302"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0x58f1b044d8308812881a1433d9bbeff99975e70c"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0xd501281565bf7789224523144fe5d98e8b28f267"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0xdda6205dc3f47e5280eb726613b27374eee9d130"
+      }
     },
-    {
-        "id": "across-protocol",
-        "symbol": "acx",
-        "name": "Across Protocol",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-            "optimistic-ethereum": "0xff733b2a3557a7ed6697007ab5d11b79fdd1b76b",
-            "arbitrum-one": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
-            "boba": "0x96821b258955587069f680729cd77369c0892b40",
-            "polygon-pos": "0xf328b73b6c685831f238c30a23fc19140cb4d8fc"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xff733b2a3557a7ed6697007ab5d11b79fdd1b76b"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d"
-            },
-            "boba": {
-                "decimal_place": 18,
-                "contract_address": "0x96821b258955587069f680729cd77369c0892b40"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0xf328b73b6c685831f238c30a23fc19140cb4d8fc"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Polygon Ecosystem",
-            "Arbitrum Ecosystem",
-            "Optimism Ecosystem",
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Across is an optimistic cross-chain bridge secured by UMA’s optimistic oracle. It is optimized for capital efficiency with a single liquidity pool, a competitive relayer landscape, and a no-slippage fee model. "
-        },
-        "links": {
-            "homepage": [
-                "https://across.to/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-                "https://ethplorer.io/address/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-                "https://optimistic.etherscan.io/token/0xFf733b2A3557a7ed6697007ab5D11B79FdD1b76B",
-                "https://arbiscan.io/token/0x53691596d1bce8cea565b84d4915e69e03d9c99d",
-                "https://blockexplorer.boba.network/tokens/0x96821b258955587069f680729cd77369c0892b40",
-                "https://polygonscan.com/token/0xf328b73b6c685831f238c30a23fc19140cb4d8fc",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://forum.across.to/",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/sKSkhTtu8s",
-                "https://medium.com/across-protocol",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "AcrossProtocol",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/across-protocol"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/28161/thumb/across-200x200.png?1668168201",
-            "small": "https://assets.coingecko.com/coins/images/28161/small/across-200x200.png?1668168201",
-            "large": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1668168201"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 1624,
-        "market_cap_rank": 961,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 0.04457748
-            },
-            "total_value_locked": {
-                "usd": 45906582
-            },
-            "mcap_to_tvl_ratio": 0.21,
-            "fdv_to_tvl_ratio": 0.97,
-            "roi": null,
-            "ath": {
-                "usd": 0.102523
-            },
-            "ath_change_percentage": {
-                "usd": -56.59791
-            },
-            "ath_date": {
-                "usd": "2023-02-26T17:19:36.011Z"
-            },
-            "atl": {
-                "usd": 0.03440846
-            },
-            "atl_change_percentage": {
-                "usd": 29.31985
-            },
-            "atl_date": {
-                "usd": "2023-06-01T08:30:40.359Z"
-            },
-            "market_cap": {
-                "usd": 9543891
-            },
-            "market_cap_rank": 961,
-            "fully_diluted_valuation": {
-                "usd": 44577480
-            },
-            "total_volume": {
-                "usd": 36143
-            },
-            "high_24h": {
-                "usd": 0.04529974
-            },
-            "low_24h": {
-                "usd": 0.04351487
-            },
-            "price_change_24h": -0.000298034199121,
-            "price_change_percentage_24h": -0.66414,
-            "price_change_percentage_7d": 0.26794,
-            "price_change_percentage_14d": 0.8603,
-            "price_change_percentage_30d": 5.56114,
-            "price_change_percentage_60d": -17.7027,
-            "price_change_percentage_200d": -18.59916,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": -63808.13922468,
-            "market_cap_change_percentage_24h": -0.66414,
-            "price_change_24h_in_currency": {
-                "usd": -0.000298034199121021
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.45795
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.66414
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 0.26794
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 0.8603
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 5.56114
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -17.7027
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -18.59916
-            },
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {
-                "usd": -63808.13922467828
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.66414
-            },
-            "total_supply": 1000000000,
-            "max_supply": 1000000000,
-            "circulating_supply": 214096702.3679336,
-            "last_updated": "2023-06-27T11:39:04.740Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:39:04.740Z"
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Harmony Ecosystem",
+      "Ethereum Ecosystem",
+      "Near Protocol Ecosystem",
+      "Avalanche Ecosystem",
+      "Polygon Ecosystem",
+      "Number",
+      "BNB Chain Ecosystem",
+      "Automated Market Maker (AMM)",
+      "Decentralized Finance (DeFi)",
+      "Decentralized Exchange (DEX)",
+      "Exchange-based Tokens"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "\"What is 1inch Network?\r\n1inch Network is a decentralized exchange (DEX) aggregator to help users discover the best trade prices for tokens. Instead of swapping tokens from a single liquidity pool of a DEX, 1inch will aggregate across different pools and suggest the most efficient way to trade tokens.\r\n\r\nWhy use 1inch?\r\nIf you are a trader trading large amount of tokens, you may not be aware of all the availability liquidity across different DEXes in order to get the best price quote. Price quote offered by DEX fluctuates according to the liquidity pool at any given time. Also, when you are trading large size, every percentage of savings can be magnified with an optimal trading path. 1inch aims to solve all that in a single user friendly interface.\r\n\r\nWhat is Pathfinder?\r\nPathfinder is the discovery and routing algorithm developed by the 1inch team. It is the algorithm the powers the backend to finding the most efficient route to swap a token. For example, if a user wants to sell ETH for WBTC, Pathfinder will explore all DEXes such as Uniswap, Curve, Balancer, DODO, Sushiswap, and more. The result is a recommended route that optimizes fees and liquidity in order to give users the best rate. Users no longer need to check each individual services in order to find the best price.\r\n\r\nWho are the creators of 1inch?\r\n1inch was founded by Sergej Kunz and Anton Bukov. The idea for 1inch was developed at a hackathon in just over 60 hours at New York City. Fast forward today, it is one of the fastest growing DeFi product.\""
     },
-   
-    {
-        "id": "alchemist",
-        "symbol": "mist",
-        "name": "Alchemist",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "MEV Protection"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "⚗️'s one and only purpose is to find the philosopher's stone and use it to explore the galaxy."
-        },
-        "links": {
-            "homepage": [
-                "https://www.alchemist.wtf/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
-                "https://ethplorer.io/address/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/alchemist",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "_alchemistcoin",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/alchemistcoin/alchemist"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14655/thumb/79158662.png?1617589045",
-            "small": "https://assets.coingecko.com/coins/images/14655/small/79158662.png?1617589045",
-            "large": "https://assets.coingecko.com/coins/images/14655/large/79158662.png?1617589045"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 13041,
-        "market_cap_rank": 1543,
-        "coingecko_rank": 614,
-        "coingecko_score": 25.698,
-        "developer_score": 37.179,
-        "community_score": 8.659,
-        "liquidity_score": 16.354,
-        "public_interest_score": 0.001,
-        "market_data": {
-            "current_price": {
-                "usd": 1.31
-            },
-            "total_value_locked": {
-                "usd": 839547
-            },
-            "mcap_to_tvl_ratio": 2.86,
-            "fdv_to_tvl_ratio": 2.86,
-            "roi": null,
-            "ath": {
-                "usd": 225.39
-            },
-            "ath_change_percentage": {
-                "usd": -99.41888
-            },
-            "ath_date": {
-                "usd": "2021-04-26T12:03:04.025Z"
-            },
-            "atl": {
-                "usd": 0.550984
-            },
-            "atl_change_percentage": {
-                "usd": 137.71414
-            },
-            "atl_date": {
-                "usd": "2023-06-21T12:28:46.822Z"
-            },
-            "market_cap": {
-                "usd": 2403243
-            },
-            "market_cap_rank": 1543,
-            "fully_diluted_valuation": {
-                "usd": 2403243
-            },
-            "total_volume": {
-                "usd": 852.3
-            },
-            "high_24h": {
-                "usd": 1.33
-            },
-            "low_24h": {
-                "usd": 1.29
-            },
-            "price_change_24h": -0.007376107438750001,
-            "price_change_percentage_24h": -0.56001,
-            "price_change_percentage_7d": 5.20491,
-            "price_change_percentage_14d": 1.23468,
-            "price_change_percentage_30d": -3.78813,
-            "price_change_percentage_60d": -15.84351,
-            "price_change_percentage_200d": -18.4999,
-            "price_change_percentage_1y": -62.11819,
-            "market_cap_change_24h": -13534.15153255,
-            "market_cap_change_percentage_24h": -0.56001,
-            "price_change_24h_in_currency": {
-                "usd": -0.007376107438749281
-            },
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.56001
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 5.20491
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 1.23468
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -3.78813
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -15.84351
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -18.4999
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -62.11819
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -13534.151532553136
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.56001
-            },
-            "total_supply": 1834863.66554973,
-            "max_supply": null,
-            "circulating_supply": 1834863.66554973,
-            "last_updated": "2023-06-27T07:36:09.498Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T07:36:09.498Z"
+    "links": {
+      "homepage": ["https://1inch.io/", "https://app.1inch.io/", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x111111111117dc0aa78b770fa6a738034120c302",
+        "https://ethplorer.io/address/0x111111111117dc0aa78b770fa6a738034120c302",
+        "https://bscscan.com/token/0x111111111117dc0aa78b770fa6a738034120c302",
+        "https://polygonscan.com/token/0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
+        "https://snowtrace.io/token/0xd501281565bf7789224523144fe5d98e8b28f267",
+        "https://avascan.info/blockchain/c/address/0xd501281565bf7789224523144fe5d98e8b28f267/token",
+        "https://explorer.energi.network/token/0xdda6205dc3f47e5280eb726613b27374eee9d130",
+        "https://nearblocks.io/token/111111111117dc0aa78b770fa6a738034120c302.factory.bridge.near",
+        "",
+        ""
+      ],
+      "official_forum_url": ["https://www.youtube.com/channel/UCk0nvK4bHpteQXZKv7lkq5w", "", ""],
+      "chat_url": ["https://discord.com/invite/1inch", "", ""],
+      "announcement_url": ["https://blog.1inch.io/", ""],
+      "twitter_screen_name": "1inch",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "OneInchNetwork",
+      "subreddit_url": "https://www.reddit.com/r/1inch/",
+      "repos_url": {
+        "github": ["https://github.com/1inch"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "alchemix",
-        "symbol": "alcx",
-        "name": "Alchemix",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-            "near-protocol": "dbdb4d16eda451d0503b854cf79d55697f90c8df.factory.bridge.near"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "dbdb4d16eda451d0503b854cf79d55697f90c8df.factory.bridge.near"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Olympus Pro",
-            "Lending/Borrowing",
-            "Yield Farming",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Alchemix token is the governance token for the Alchemix protocol. "
-        },
-        "links": {
-            "homepage": [
-                "https://alchemix.fi/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-                "https://ethplorer.io/address/0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-                "https://nearblocks.io/token/dbdb4d16eda451d0503b854cf79d55697f90c8df.factory.bridge.near",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/zAd6dzgwaj",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://alchemixfi.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "alchemixfi",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/alchemix-finance"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874",
-            "small": "https://assets.coingecko.com/coins/images/14113/small/Alchemix.png?1614409874",
-            "large": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1614409874"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 21647,
-        "market_cap_rank": 575,
-        "coingecko_rank": 1045,
-        "coingecko_score": 21.093,
-        "developer_score": 0,
-        "community_score": 9.422,
-        "liquidity_score": 30.295,
-        "public_interest_score": 0.002,
-        "market_data": {
-            "current_price": {
-                "usd": 15.15
-            },
-            "total_value_locked": {
-                "usd": 68029802
-            },
-            "mcap_to_tvl_ratio": 0.41,
-            "fdv_to_tvl_ratio": 0.53,
-            "roi": null,
-            "ath": {
-                "usd": 2066.2
-            },
-            "ath_change_percentage": {
-                "usd": -99.26688
-            },
-            "ath_date": {
-                "usd": "2021-03-20T19:33:19.740Z"
-            },
-            "atl": {
-                "usd": 12.84
-            },
-            "atl_change_percentage": {
-                "usd": 17.9906
-            },
-            "atl_date": {
-                "usd": "2023-06-15T11:31:15.772Z"
-            },
-            "market_cap": {
-                "usd": 28147721
-            },
-            "market_cap_rank": 575,
-            "fully_diluted_valuation": {
-                "usd": 36236240
-            },
-            "total_volume": {
-                "usd": 911328
-            },
-            "high_24h": {
-                "usd": 15.76
-            },
-            "low_24h": {
-                "usd": 15.14
-            },
-            "price_change_24h": -0.1181327679527,
-            "price_change_percentage_24h": -0.77362,
-            "price_change_percentage_7d": 10.54005,
-            "price_change_percentage_14d": 8.63111,
-            "price_change_percentage_30d": -11.21286,
-            "price_change_percentage_60d": -15.62686,
-            "price_change_percentage_200d": -14.96472,
-            "price_change_percentage_1y": -41.06655,
-            "market_cap_change_24h": -197977.9820336,
-            "market_cap_change_percentage_24h": -0.69844,
-            "price_change_24h_in_currency": {
-                "usd": -0.11813276795267313
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.01229
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.77362
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 10.54005
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 8.63111
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -11.21286
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -15.62686
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -14.96472
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -41.06655
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -197977.98203356192
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.69844
-            },
-            "total_supply": 2660219.34481202,
-            "max_supply": 2393060,
-            "circulating_supply": 1858889.9936558593,
-            "last_updated": "2023-06-27T11:39:42.755Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:39:42.755Z"
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028",
+      "small": "https://assets.coingecko.com/coins/images/13469/small/1inch-token.png?1608803028",
+      "large": "https://assets.coingecko.com/coins/images/13469/large/1inch-token.png?1608803028"
     },
-    {
-        "id": "alchemix-usd",
-        "symbol": "alusd",
-        "name": "Alchemix USD",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9",
-            "optimistic-ethereum": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
-            "fantom": "0xb67fa6defce4042070eb1ae1511dcd6dcc6a532e"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0xb67fa6defce4042070eb1ae1511dcd6dcc6a532e"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Fantom Ecosystem",
-            "Optimism Ecosystem",
-            "Ethereum Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "USD Stablecoin",
-            "Stablecoins"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "alUSD is a yield-backed synthetic stablecoin powered by the Alchemix protocol"
-        },
-        "links": {
-            "homepage": [
-                "https://alchemix.fi/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9",
-                "https://ethplorer.io/address/0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9",
-                "https://optimistic.etherscan.io/token/0xCB8FA9a76b8e203D8C3797bF438d8FB81Ea3326A",
-                "https://ftmscan.com/token/0xB67FA6deFCe4042070Eb1ae1511Dcd6dcc6a532E",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/qWfMzCmSHX",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://alchemixfi.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "AlchemixFi",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/alchemix-finance"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14114/thumb/Alchemix_USD.png?1614410406",
-            "small": "https://assets.coingecko.com/coins/images/14114/small/Alchemix_USD.png?1614410406",
-            "large": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1614410406"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 1069,
-        "market_cap_rank": 182,
-        "coingecko_rank": 1100,
-        "coingecko_score": 20.783,
-        "developer_score": 0,
-        "community_score": 9.422,
-        "liquidity_score": 22.161,
-        "public_interest_score": 0.002,
-        "market_data": {
-            "current_price": {
-                "usd": 0.994364
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 2.13
-            },
-            "ath_change_percentage": {
-                "usd": -53.24109
-            },
-            "ath_date": {
-                "usd": "2021-03-21T19:53:32.860Z"
-            },
-            "atl": {
-                "usd": 0.060239
-            },
-            "atl_change_percentage": {
-                "usd": 1551.29095
-            },
-            "atl_date": {
-                "usd": "2021-03-19T22:40:28.697Z"
-            },
-            "market_cap": {
-                "usd": 170568144
-            },
-            "market_cap_rank": 182,
-            "fully_diluted_valuation": {
-                "usd": 170568144
-            },
-            "total_volume": {
-                "usd": 424959
-            },
-            "high_24h": {
-                "usd": 1.003
-            },
-            "low_24h": {
-                "usd": 0.989011
-            },
-            "price_change_24h": -0.005207614351201001,
-            "price_change_percentage_24h": -0.52098,
-            "price_change_percentage_7d": -0.36636,
-            "price_change_percentage_14d": -0.57051,
-            "price_change_percentage_30d": -0.22445,
-            "price_change_percentage_60d": -0.16209,
-            "price_change_percentage_200d": 0.50587,
-            "price_change_percentage_1y": -0.64556,
-            "market_cap_change_24h": -894038.370077,
-            "market_cap_change_percentage_24h": -0.52142,
-            "price_change_24h_in_currency": {
-                "usd": -0.005207614351200763
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.15139
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.52098
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -0.36636
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -0.57051
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -0.22445
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -0.16209
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 0.50587
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -0.64556
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -894038.3700765967
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.52142
-            },
-            "total_supply": 171534991.556008,
-            "max_supply": null,
-            "circulating_supply": 171534991.556008,
-            "last_updated": "2023-06-27T11:39:14.426Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:39:14.426Z"
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x111111111117dc0aa78b770fa6a738034120c302",
+    "sentiment_votes_up_percentage": 84.62,
+    "sentiment_votes_down_percentage": 15.38,
+    "watchlist_portfolio_users": 105058,
+    "market_cap_rank": 113,
+    "coingecko_rank": 266,
+    "coingecko_score": 33.994,
+    "developer_score": 0,
+    "community_score": 38.915,
+    "liquidity_score": 53.381,
+    "public_interest_score": 0.062,
+    "market_data": {
+      "current_price": {
+        "usd": 0.338363
+      },
+      "total_value_locked": {
+        "usd": 5808069
+      },
+      "mcap_to_tvl_ratio": 55.03,
+      "fdv_to_tvl_ratio": 87.5,
+      "roi": null,
+      "ath": {
+        "usd": 8.65
+      },
+      "ath_change_percentage": {
+        "usd": -96.09442
+      },
+      "ath_date": {
+        "usd": "2021-10-27T08:24:54.808Z"
+      },
+      "atl": {
+        "usd": 0.254171
+      },
+      "atl_change_percentage": {
+        "usd": 32.94026
+      },
+      "atl_date": {
+        "usd": "2023-06-15T17:41:38.825Z"
+      },
+      "market_cap": {
+        "usd": 319608633
+      },
+      "market_cap_rank": 113,
+      "fully_diluted_valuation": {
+        "usd": 508205252
+      },
+      "total_volume": {
+        "usd": 23857286
+      },
+      "high_24h": {
+        "usd": 0.343467
+      },
+      "low_24h": {
+        "usd": 0.318601
+      },
+      "price_change_24h": 0.0168583,
+      "price_change_percentage_24h": 5.24357,
+      "price_change_percentage_7d": 5.41989,
+      "price_change_percentage_14d": 23.99417,
+      "price_change_percentage_30d": -10.45532,
+      "price_change_percentage_60d": -25.11122,
+      "price_change_percentage_200d": -21.01283,
+      "price_change_percentage_1y": -45.65938,
+      "market_cap_change_24h": 15008449,
+      "market_cap_change_percentage_24h": 4.92726,
+      "price_change_24h_in_currency": {
+        "usd": 0.0168583
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.55276
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 5.24357
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 5.41989
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 23.99417
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -10.45532
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -25.11122
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -21.01283
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -45.65938
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 15008449
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.92726
+      },
+      "total_supply": 1500000000,
+      "max_supply": 1500000000,
+      "circulating_supply": 943345129.835729,
+      "last_updated": "2023-07-03T17:46:13.162Z"
     },
-    {
-        "id": "ampleforth",
-        "symbol": "ampl",
-        "name": "Ampleforth",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
-            "near-protocol": "77fba179c79de5b7653f68b5039af940ada60ce0.factory.bridge.near",
-            "harmony-shard-0": "0xf2f5bf00cd952f3f980a02f5dce278cbff4dae05",
-            "binance-smart-chain": "0xdb021b1b247fe2f1fa57e0a87c748cc1e321f07f",
-            "avalanche": "0x027dbca046ca156de9622cd1e2d907d375e53aa7",
-            "energi": "0x79786ed8a70ccec6c7a31debc7fefc5119f9dc95"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 9,
-                "contract_address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "77fba179c79de5b7653f68b5039af940ada60ce0.factory.bridge.near"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 9,
-                "contract_address": "0xf2f5bf00cd952f3f980a02f5dce278cbff4dae05"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 9,
-                "contract_address": "0xdb021b1b247fe2f1fa57e0a87c748cc1e321f07f"
-            },
-            "avalanche": {
-                "decimal_place": 9,
-                "contract_address": "0x027dbca046ca156de9622cd1e2d907d375e53aa7"
-            },
-            "energi": {
-                "decimal_place": 9,
-                "contract_address": "0x79786ed8a70ccec6c7a31debc7fefc5119f9dc95"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Harmony Ecosystem",
-            "Ethereum Ecosystem",
-            "Avalanche Ecosystem",
-            "BNB Chain Ecosystem",
-            "Near Protocol Ecosystem",
-            "Rebase Tokens",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Ampleforth is a digital-asset-protocol for smart commodity-money.\r\n\r\nThe smart commodity money with a unique elastic supply protocol. AMPL supply expands and contracts in response to it’s price deviating from a 1 USD target. Deviations result in a supply change of AMPLs once every 24 hours, increasing or decreasing the number of tokens in each holder’s wallet pro-rata. Ampleforth is the only asset in the world with this elastic supply property, and therefore has counter-cyclical trading pressure and is uncorrelated with other digital assets such as Bitcoin."
-        },
-        "links": {
-            "homepage": [
-                "https://www.ampleforth.org/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xd46ba6d942050d489dbd938a2c909a5d5039a161",
-                "https://ethplorer.io/address/0xd46ba6d942050d489dbd938a2c909a5d5039a161",
-                "https://bscscan.com/token/0xdb021b1b247fe2f1fa57e0a87c748cc1e321f07f",
-                "https://cchain.explorer.avax.network/token/0x027dbcA046ca156De9622cD1e2D907d375e53aa7/token-transfers",
-                "https://snowtrace.io/token/0x027dbca046ca156de9622cd1e2d907d375e53aa7",
-                "https://avascan.info/blockchain/c/address/0x027dbca046ca156de9622cd1e2d907d375e53aa7/token",
-                "https://explorer.energi.network/token/0x79786Ed8a70ccEC6C7A31debC7FeFc5119f9dc95",
-                "https://nearblocks.io/token/77fba179c79de5b7653f68b5039af940ada60ce0.factory.bridge.near",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://www.facebook.com/ampleforthprotocol/",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "ampleforthorg",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "Ampleforth",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/ampleforth/uFragments",
-                    "https://github.com/ampleforth/market-oracle"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/4708/thumb/Ampleforth.png?1561684250",
-            "small": "https://assets.coingecko.com/coins/images/4708/small/Ampleforth.png?1561684250",
-            "large": "https://assets.coingecko.com/coins/images/4708/large/Ampleforth.png?1561684250"
-        },
-        "country_origin": "US",
-        "genesis_date": null,
-        "contract_address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
-        "sentiment_votes_up_percentage": 75,
-        "sentiment_votes_down_percentage": 25,
-        "ico_data": {
-            "ico_start_date": "2019-06-13T13:00:00.000Z",
-            "ico_end_date": "2019-06-19T13:00:00.000Z",
-            "short_desc": "A low volatility cryptocurrency & platform",
-            "description": null,
-            "links": {},
-            "softcap_currency": "",
-            "hardcap_currency": "USD",
-            "total_raised_currency": "",
-            "softcap_amount": null,
-            "hardcap_amount": "4900000.0",
-            "total_raised": null,
-            "quote_pre_sale_currency": "",
-            "base_pre_sale_amount": null,
-            "quote_pre_sale_amount": null,
-            "quote_public_sale_currency": "",
-            "base_public_sale_amount": 0,
-            "quote_public_sale_amount": 0,
-            "accepting_currencies": "",
-            "country_origin": "US",
-            "pre_sale_start_date": null,
-            "pre_sale_end_date": null,
-            "whitelist_url": "",
-            "whitelist_start_date": null,
-            "whitelist_end_date": null,
-            "bounty_detail_url": "",
-            "amount_for_sale": null,
-            "kyc_required": true,
-            "whitelist_available": null,
-            "pre_sale_available": null,
-            "pre_sale_ended": false
-        },
-        "watchlist_portfolio_users": 20248,
-        "market_cap_rank": 561,
-        "coingecko_rank": 290,
-        "coingecko_score": 33.178,
-        "developer_score": 53.613,
-        "community_score": 8.955,
-        "liquidity_score": 23.198,
-        "public_interest_score": 0.004,
-        "market_data": {
-            "current_price": {
-                "usd": 1.28
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 4.07
-            },
-            "ath_change_percentage": {
-                "usd": -68.61366
-            },
-            "ath_date": {
-                "usd": "2020-07-12T20:49:38.893Z"
-            },
-            "atl": {
-                "usd": 0.155869
-            },
-            "atl_change_percentage": {
-                "usd": 718.85017
-            },
-            "atl_date": {
-                "usd": "2019-10-31T23:34:28.705Z"
-            },
-            "market_cap": {
-                "usd": 29193766
-            },
-            "market_cap_rank": 561,
-            "fully_diluted_valuation": {
-                "usd": 35866427
-            },
-            "total_volume": {
-                "usd": 677299
-            },
-            "high_24h": {
-                "usd": 1.48
-            },
-            "low_24h": {
-                "usd": 1.27
-            },
-            "price_change_24h": -0.20138575671848,
-            "price_change_percentage_24h": -13.60938,
-            "price_change_percentage_7d": 15.96828,
-            "price_change_percentage_14d": 23.67815,
-            "price_change_percentage_30d": 11.11506,
-            "price_change_percentage_60d": 16.9049,
-            "price_change_percentage_200d": -20.50054,
-            "price_change_percentage_1y": 42.81096,
-            "market_cap_change_24h": -3826512.4680713,
-            "market_cap_change_percentage_24h": -11.58837,
-            "price_change_24h_in_currency": {
-                "usd": -0.20138575671847558
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.17993
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -13.60938
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 15.96828
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 23.67815
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 11.11506
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": 16.9049
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -20.50054
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 42.81096
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -3826512.4680713564
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -11.58837
-            },
-            "total_supply": 28056340.5683925,
-            "max_supply": null,
-            "circulating_supply": 22836683.092471667,
-            "last_updated": "2023-06-27T11:40:03.820Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 72590,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:40:03.820Z"
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
     },
-    {
-        "id": "ankreth",
-        "symbol": "ankreth",
-        "name": "Ankr Staked ETH",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
-            "fantom": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-            "avalanche": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-            "polygon-zkevm": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-            "arbitrum-one": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
-            "binance-smart-chain": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c"
-            },
-            "polygon-zkevm": {
-                "decimal_place": 18,
-                "contract_address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "BNB Chain Ecosystem",
-            "Arbitrum Ecosystem",
-            "Avalanche Ecosystem",
-            "Fantom Ecosystem",
-            "Ethereum Ecosystem",
-            "Liquid Staking Tokens",
-            "Eth 2.0 Staking"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "ETH Liquid Staking with Ankr\r\n\r\nAnkr Staking offers Ethereum token holders the opportunity to stake ETH and, in return, claim ETH Liquid Staking tokens — ankrETH. ankrETH also offers instant liquidity for your staked ETH, enabling you to connect ankrETH with DeFi platforms and earn several more layers of rewards.\r\n\r\nankrETH is a reward-bearing token, meaning that the fair value of 1 ankrETH token vs. ETH increases over time as staking rewards accumulate inside the token.\r\n\r\nBenefits\r\n\r\n- Generate Multiple Layers of Rewards: Use ankrETH on DeFi platforms to enable you to multiply your earning potential in APY on top of your staking rewards!\r\n- Low Impermanent Loss: Contributing ankrETH for liquidity with tokens like ETH means a low risk of impermanent loss, expanding the upside of providing liquidity for a more stable and profitable experience.\r\n- Compound Your Staking Rewards: Your staking rewards will compound daily as the value of ankrETH in your wallet increases vs. ETH.\r\n- Support & Secure Ethereum: Staking ETH directly supports the Ethereum network and helps validate transactions. Ankr’s staking system distributes staked tokens intelligently across the Ethereum ecosystem to achieve optimal decentralization.\r\n- Elastic Supply: Users can trade their ankrETH tokens for their staked ETH anytime.\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://www.ankr.com/about-staking/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
-                "https://ethplorer.io/address/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
-                "https://ftmscan.com/token/0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
-                "https://snowtrace.io/token/0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-                "https://avascan.info/blockchain/c/address/0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c/token",
-                "https://zkevm.polygonscan.com/token/0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-                "https://arbiscan.io/token/0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
-                "https://bscscan.com/token/0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/ankr",
-                "https://medium.com/ankr-network",
-                "https://youtube.com/@AnkrOfficial"
-            ],
-            "announcement_url": [
-                "https://medium.com/ankr-network",
-                ""
-            ],
-            "twitter_screen_name": "ankr",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "ankrnetwork",
-            "subreddit_url": "https://www.reddit.com/r/Ankrofficial",
-            "repos_url": {
-                "github": [
-                    "https://github.com/Ankr-network/stkr-smartcontract-public"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/13403/thumb/aETHc.png?1625756490",
-            "small": "https://assets.coingecko.com/coins/images/13403/small/aETHc.png?1625756490",
-            "large": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1625756490"
-        },
-        "country_origin": "US",
-        "genesis_date": null,
-        "contract_address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 1075,
-        "market_cap_rank": 283,
-        "coingecko_rank": 1807,
-        "coingecko_score": 16,
-        "developer_score": 0,
-        "community_score": 10.378,
-        "liquidity_score": 1,
-        "public_interest_score": 0.004,
-        "market_data": {
-            "current_price": {
-                "usd": 2098.24
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 4733.13
-            },
-            "ath_change_percentage": {
-                "usd": -55.66498
-            },
-            "ath_date": {
-                "usd": "2021-11-26T04:33:49.980Z"
-            },
-            "atl": {
-                "usd": 534.32
-            },
-            "atl_change_percentage": {
-                "usd": 292.73278
-            },
-            "atl_date": {
-                "usd": "2020-12-24T06:45:06.825Z"
-            },
-            "market_cap": {
-                "usd": 87686507
-            },
-            "market_cap_rank": 283,
-            "fully_diluted_valuation": {
-                "usd": 87686507
-            },
-            "total_volume": {
-                "usd": 53441
-            },
-            "high_24h": {
-                "usd": 2123.61
-            },
-            "low_24h": {
-                "usd": 2057.4
-            },
-            "price_change_24h": 9.69,
-            "price_change_percentage_24h": 0.46387,
-            "price_change_percentage_7d": 8.30688,
-            "price_change_percentage_14d": 7.28024,
-            "price_change_percentage_30d": 2.33822,
-            "price_change_percentage_60d": -1.05601,
-            "price_change_percentage_200d": 67.21897,
-            "price_change_percentage_1y": 92.84265,
-            "market_cap_change_24h": 683196,
-            "market_cap_change_percentage_24h": 0.78525,
-            "price_change_24h_in_currency": {
-                "usd": 9.69
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.12512
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.46387
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 8.30688
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 7.28024
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 2.33822
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -1.05601
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 67.21897
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 92.84265
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 683196
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0.78525
-            },
-            "total_supply": 41790.72224941,
-            "max_supply": null,
-            "circulating_supply": 41790.72224941,
-            "last_updated": "2023-06-27T11:40:13.519Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:40:13.519Z"
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:13.162Z"
+  },
+  {
+    "id": "aave",
+    "symbol": "aave",
+    "name": "Aave",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+      "near-protocol": "7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.factory.bridge.near",
+      "binance-smart-chain": "0xfb6115445bff7b52feb98650c87f44907e58f802",
+      "huobi-token": "0x202b4936fe1a82a4965220860ae46d7d3939bb25",
+      "polygon-pos": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+      "fantom": "0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b",
+      "harmony-shard-0": "0xcf323aad9e522b93f11c352caa519ad0e14eb40f",
+      "avalanche": "0x63a72806098bd3d9520cc43356dd78afe5d386d9",
+      "sora": "0x0091bd8d8295b25cab5a7b8b0e44498e678cfc15d872ede3215f7d4c7635ba36",
+      "energi": "0xa7f2f790355e0c32cab03f92f6eb7f488e6f049a",
+      "optimistic-ethereum": "0x76fb31fb4af56892a25e32cfc43de717950c9278"
     },
-    {
-        "id": "arbitrum",
-        "symbol": "arb",
-        "name": "Arbitrum",
-        "asset_platform_id": "arbitrum-one",
-        "platforms": {
-            "arbitrum-one": "0x912ce59144191c1204e64559fe8253a0e49e6548",
-            "arbitrum-nova": "0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad",
-            "ethereum": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1"
-        },
-        "detail_platforms": {
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x912ce59144191c1204e64559fe8253a0e49e6548"
-            },
-            "arbitrum-nova": {
-                "decimal_place": 18,
-                "contract_address": "0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad"
-            },
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Arbitrum Nova Ecosystem",
-            "Ethereum Ecosystem",
-            "Arbitrum Ecosystem",
-            "Layer 2 (L2)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Arbitrum is one of the leading Ethereum scaling solutions bringing cheap transactions to tens of thousands of users in an environment that feels very similar to Ethereum. It is an optimistic rollup and the leading L2 in terms of TVL. Some of the largest dApps live on Arbitrum include GMX, Radiant, Uniswap V3, and Gains Network."
-        },
-        "links": {
-            "homepage": [
-                "https://arbitrum.io/",
-                "http://arbitrum.foundation",
-                ""
-            ],
-            "blockchain_site": [
-                "https://arbiscan.io/token/0x912ce59144191c1204e64559fe8253a0e49e6548",
-                "https://etherscan.io/token/0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
-                "https://ethplorer.io/address/0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
-                "https://nova.arbiscan.io/token/0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad",
-                "https://www.oklink.com/arbitrum",
-                "https://3xpl.com/arbitrum-one",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/Arbitrum",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "arbitrum",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/ArbitrumFoundation"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/16547/thumb/photo_2023-03-29_21.47.00.jpeg?1680097630",
-            "small": "https://assets.coingecko.com/coins/images/16547/small/photo_2023-03-29_21.47.00.jpeg?1680097630",
-            "large": "https://assets.coingecko.com/coins/images/16547/large/photo_2023-03-29_21.47.00.jpeg?1680097630"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
-        "sentiment_votes_up_percentage": 85.71,
-        "sentiment_votes_down_percentage": 14.29,
-        "watchlist_portfolio_users": 76492,
-        "market_cap_rank": 36,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 1.21
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 8.67
-            },
-            "ath_change_percentage": {
-                "usd": -86.08485
-            },
-            "ath_date": {
-                "usd": "2023-03-23T13:10:03.106Z"
-            },
-            "atl": {
-                "usd": 0.912886
-            },
-            "atl_change_percentage": {
-                "usd": 32.2068
-            },
-            "atl_date": {
-                "usd": "2023-06-15T07:25:14.752Z"
-            },
-            "market_cap": {
-                "usd": 1544689314
-            },
-            "market_cap_rank": 36,
-            "fully_diluted_valuation": {
-                "usd": 12115210305
-            },
-            "total_volume": {
-                "usd": 370040946
-            },
-            "high_24h": {
-                "usd": 1.22
-            },
-            "low_24h": {
-                "usd": 1.12
-            },
-            "price_change_24h": 0.070709,
-            "price_change_percentage_24h": 6.19427,
-            "price_change_percentage_7d": 21.11796,
-            "price_change_percentage_14d": 20.24742,
-            "price_change_percentage_30d": 0.74845,
-            "price_change_percentage_60d": -14.92032,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": 95882657,
-            "market_cap_change_percentage_24h": 6.61804,
-            "price_change_24h_in_currency": {
-                "usd": 0.070709
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.69692
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 6.19427
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 21.11796
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 20.24742
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 0.74845
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -14.92032
-            },
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {
-                "usd": 95882657
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 6.61804
-            },
-            "total_supply": 10000000000,
-            "max_supply": 10000000000,
-            "circulating_supply": 1275000000,
-            "last_updated": "2023-06-27T11:39:41.566Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:39:41.566Z"
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.factory.bridge.near"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xfb6115445bff7b52feb98650c87f44907e58f802"
+      },
+      "huobi-token": {
+        "decimal_place": 18,
+        "contract_address": "0x202b4936fe1a82a4965220860ae46d7d3939bb25"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0xcf323aad9e522b93f11c352caa519ad0e14eb40f"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x63a72806098bd3d9520cc43356dd78afe5d386d9"
+      },
+      "sora": {
+        "decimal_place": 18,
+        "contract_address": "0x0091bd8d8295b25cab5a7b8b0e44498e678cfc15d872ede3215f7d4c7635ba36"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0xa7f2f790355e0c32cab03f92f6eb7f488e6f049a"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x76fb31fb4af56892a25e32cfc43de717950c9278"
+      }
     },
-    {
-        "id": "aura-bal",
-        "symbol": "aurabal",
-        "name": "Aura BAL",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Decentralized Finance (DeFi)",
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "auraBAL is a liquid wrapper for Balancer's veBAL. Aura allows users to deposit their 80/20 BAL/WETH BPT and receive liquid auraBAL, instead of the non-transferrable veBAL. Tokenised auraBAL is given to the user at a 1:1 rate for veBAL, and can be traded on Balancer or elsewhere.\r\n\r\nThis BPT is then locked up by the Aura protocol for the maximum time in Balancer Voting Escrow where it will allow the Aura system to benefit from its voting power for boosting rewards & voting for gauges."
-        },
-        "links": {
-            "homepage": [
-                "https://aura.finance/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
-                "https://ethplorer.io/address/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://mirror.xyz/0xfEE0Bbe31345a7c27368534fEf45a57133FF3A86",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/aurafinance",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "AuraFinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "aurafinance",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/aurafinance"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/26538/thumb/auraBAL.png?1658721102",
-            "small": "https://assets.coingecko.com/coins/images/26538/small/auraBAL.png?1658721102",
-            "large": "https://assets.coingecko.com/coins/images/26538/large/auraBAL.png?1658721102"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 263,
-        "market_cap_rank": 455,
-        "coingecko_rank": 5922,
-        "coingecko_score": 1.912,
-        "developer_score": 0,
-        "community_score": 7.78,
-        "liquidity_score": 1,
-        "public_interest_score": 0.003,
-        "market_data": {
-            "current_price": {
-                "usd": 13.09
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 21.61
-            },
-            "ath_change_percentage": {
-                "usd": -39.40991
-            },
-            "ath_date": {
-                "usd": "2023-01-31T20:55:03.507Z"
-            },
-            "atl": {
-                "usd": 8.2
-            },
-            "atl_change_percentage": {
-                "usd": 59.71664
-            },
-            "atl_date": {
-                "usd": "2022-11-09T13:15:21.224Z"
-            },
-            "market_cap": {
-                "usd": 40810418
-            },
-            "market_cap_rank": 455,
-            "fully_diluted_valuation": {
-                "usd": 40810418
-            },
-            "total_volume": {
-                "usd": 223598
-            },
-            "high_24h": {
-                "usd": 13.15
-            },
-            "low_24h": {
-                "usd": 12.73
-            },
-            "price_change_24h": 0.04329426,
-            "price_change_percentage_24h": 0.33191,
-            "price_change_percentage_7d": 5.64145,
-            "price_change_percentage_14d": 6.93786,
-            "price_change_percentage_30d": -7.69917,
-            "price_change_percentage_60d": -19.48796,
-            "price_change_percentage_200d": 14.31278,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": 171884,
-            "market_cap_change_percentage_24h": 0.42296,
-            "price_change_24h_in_currency": {
-                "usd": 0.04329426
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.14594
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.33191
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 5.64145
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 6.93786
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -7.69917
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -19.48796
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 14.31278
-            },
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {
-                "usd": 171884
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0.42296
-            },
-            "total_supply": 3118321.99690298,
-            "max_supply": null,
-            "circulating_supply": 3118321.99690298,
-            "last_updated": "2023-06-27T11:38:40.125Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:38:40.125Z"
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Harmony Ecosystem",
+      "Optimism Ecosystem",
+      "Ethereum Ecosystem",
+      "BNB Chain Ecosystem",
+      "Fantom Ecosystem",
+      "Avalanche Ecosystem",
+      "Polygon Ecosystem",
+      "Near Protocol Ecosystem",
+      "Lending/Borrowing",
+      "Governance",
+      "Yield Farming",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Aave is a decentralized money market protocol where users can lend and borrow cryptocurrency across 20 different assets as collateral. The protocol has a native token called AAVE, which is also a governance token that lets the community decide the direction of the protocol in a collective manner. Lenders can earn interest by providing liquidity to the market, while borrowers can borrow by collateralizing their cryptoassets to take out loans from the liquidity pools.\r\n\r\n"
     },
-    {
-        "id": "aura-finance",
-        "symbol": "aura",
-        "name": "Aura Finance",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Decentralized Finance (DeFi)",
-            "Metagovernance",
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Centered around Balancer’s veBAL, Aura coordinates incentives around vote-escrowed tokens to boost yield potential and governance power of DeFi liquidity providers, governance token stakers and voters."
-        },
-        "links": {
-            "homepage": [
-                "https://aura.finance",
-                "https://app.aura.finance",
-                "https://docs.aura.finance"
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/address/0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
-                "https://etherscan.io/token/0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
-                "https://ethplorer.io/address/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://mirror.xyz/0xfEE0Bbe31345a7c27368534fEf45a57133FF3A86",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/aurafinance",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "aurafinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "aurafinance",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/aurafinance/"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1654784187",
-            "small": "https://assets.coingecko.com/coins/images/25942/small/logo.png?1654784187",
-            "large": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1654784187"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 6421,
-        "market_cap_rank": 408,
-        "coingecko_rank": 1579,
-        "coingecko_score": 17.272,
-        "developer_score": 0,
-        "community_score": 7.78,
-        "liquidity_score": 13.758,
-        "public_interest_score": 0.003,
-        "market_data": {
-            "current_price": {
-                "usd": 1.69
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 4.05
-            },
-            "ath_change_percentage": {
-                "usd": -58.11638
-            },
-            "ath_date": {
-                "usd": "2023-03-14T13:19:41.812Z"
-            },
-            "atl": {
-                "usd": 0.445907
-            },
-            "atl_change_percentage": {
-                "usd": 280.04987
-            },
-            "atl_date": {
-                "usd": "2022-06-17T07:20:33.005Z"
-            },
-            "market_cap": {
-                "usd": 48088348
-            },
-            "market_cap_rank": 408,
-            "fully_diluted_valuation": {
-                "usd": 169440471
-            },
-            "total_volume": {
-                "usd": 302214
-            },
-            "high_24h": {
-                "usd": 1.73
-            },
-            "low_24h": {
-                "usd": 1.66
-            },
-            "price_change_24h": -0.00069975106692,
-            "price_change_percentage_24h": -0.04128,
-            "price_change_percentage_7d": 7.04289,
-            "price_change_percentage_14d": -0.08891,
-            "price_change_percentage_30d": -7.80187,
-            "price_change_percentage_60d": -27.17234,
-            "price_change_percentage_200d": -22.92182,
-            "price_change_percentage_1y": 14.4075,
-            "market_cap_change_24h": -19859.4071918,
-            "market_cap_change_percentage_24h": -0.04128,
-            "price_change_24h_in_currency": {
-                "usd": -0.000699751066916887
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.25469
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.04128
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 7.04289
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -0.08891
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -7.80187
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -27.17234
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -22.92182
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 14.4075
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -19859.40719179064
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.04128
-            },
-            "total_supply": 62518530.3121778,
-            "max_supply": 100000000,
-            "circulating_supply": 28380674.4008115,
-            "last_updated": "2023-06-27T11:38:26.421Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:38:26.421Z"
+    "links": {
+      "homepage": ["https://app.aave.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+        "https://ethplorer.io/address/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+        "https://hecoinfo.com/token/0x202b4936fe1a82a4965220860ae46d7d3939bb25",
+        "https://polygonscan.com/token/0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "https://snowtrace.io/token/0x63a72806098bd3d9520cc43356dd78afe5d386d9",
+        "https://nearblocks.io/token/7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.factory.bridge.near",
+        "https://ftmscan.com/token/0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b",
+        "https://scan.meter.io/address/0x6a07a792ab2965c72a5b8088d3a069a7ac3a993b",
+        "https://optimistic.etherscan.io/token/0x76fb31fb4af56892a25e32cfc43de717950c9278",
+        "https://avascan.info/blockchain/c/address/0x63a72806098bd3d9520cc43356dd78afe5d386d9/token"
+      ],
+      "official_forum_url": ["https://www.instagram.com/aave.aave/", "", ""],
+      "chat_url": ["https://aave.com/discord", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "AaveAave",
+      "facebook_username": "AaveCom",
+      "bitcointalk_thread_identifier": 2090735,
+      "telegram_channel_identifier": "Aavesome",
+      "subreddit_url": "https://www.reddit.com/r/Aave_Official",
+      "repos_url": {
+        "github": ["https://github.com/aave/aave-protocol"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "badger-dao",
-        "symbol": "badger",
-        "name": "Badger DAO",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
-            "xdai": "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65",
-            "fantom": "0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
-            "harmony-shard-0": "0x06b19a0ce12dc71f1c7a6dd39e8983e089c40e0d",
-            "arbitrum-one": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
-            "energi": "0x32e6842a6ea6a913687885ac856c2493b5b12f6f"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x3472a5a71965499acd81997a54bba8d852c6e53d"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0x06b19a0ce12dc71f1c7a6dd39e8983e089c40e0d"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0x32e6842a6ea6a913687885ac856c2493b5b12f6f"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Fantom Ecosystem",
-            "Arbitrum Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Polygon Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Governance",
-            "Yield Farming",
-            "Yield Aggregator"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Badger DAO aims to create an ecosystem of DeFi products with the ultimate goal of bringing Bitcoin into Ethereum. It is the first DeFi project that chose to focus on BTC as the main reserve asset rather than using ETH. \r\n\r\nDuring launch, there are two main products, Sett and DIGG. "
-        },
-        "links": {
-            "homepage": [
-                "https://app.badger.finance/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x3472a5a71965499acd81997a54bba8d852c6e53d",
-                "https://ethplorer.io/address/0x3472a5a71965499acd81997a54bba8d852c6e53d",
-                "https://blockscout.com/poa/xdai/tokens/0xdfc20AE04ED70bd9c7D720F449eEDAe19F659D65/token-transfers",
-                "https://arbiscan.io/token/0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
-                "https://ftmscan.com/token/0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
-                "https://scan.meter.io/address/0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
-                "https://ftmscan.com/address/0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
-                "https://explorer.energi.network/token/0x32e6842a6ea6a913687885ac856c2493b5b12f6f",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/badgerdao",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://badgerdao.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "badgerdao",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "badger_dao",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/Badger-Finance",
-                    "https://github.com/Badger-Finance/badger-system"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
-            "small": "https://assets.coingecko.com/coins/images/13287/small/badger_dao_logo.jpg?1607054976",
-            "large": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1607054976"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
-        "sentiment_votes_up_percentage": 50,
-        "sentiment_votes_down_percentage": 50,
-        "watchlist_portfolio_users": 22734,
-        "market_cap_rank": 427,
-        "coingecko_rank": 805,
-        "coingecko_score": 23.207,
-        "developer_score": 0,
-        "community_score": 9.094,
-        "liquidity_score": 38.848,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 2.26
-            },
-            "total_value_locked": {
-                "usd": 35206133
-            },
-            "mcap_to_tvl_ratio": 1.26,
-            "fdv_to_tvl_ratio": 1.35,
-            "roi": null,
-            "ath": {
-                "usd": 89.08
-            },
-            "ath_change_percentage": {
-                "usd": -97.45514
-            },
-            "ath_date": {
-                "usd": "2021-02-09T01:03:21.398Z"
-            },
-            "atl": {
-                "usd": 1.83
-            },
-            "atl_change_percentage": {
-                "usd": 23.63077
-            },
-            "atl_date": {
-                "usd": "2023-06-10T04:30:39.245Z"
-            },
-            "market_cap": {
-                "usd": 44197312
-            },
-            "market_cap_rank": 427,
-            "fully_diluted_valuation": {
-                "usd": 47583357
-            },
-            "total_volume": {
-                "usd": 1848238
-            },
-            "high_24h": {
-                "usd": 2.3
-            },
-            "low_24h": {
-                "usd": 2.2
-            },
-            "price_change_24h": -0.007389872916370001,
-            "price_change_percentage_24h": -0.32651,
-            "price_change_percentage_7d": 8.61339,
-            "price_change_percentage_14d": 10.16421,
-            "price_change_percentage_30d": -8.4558,
-            "price_change_percentage_60d": -19.60443,
-            "price_change_percentage_200d": -14.3147,
-            "price_change_percentage_1y": -32.906,
-            "market_cap_change_24h": 124475,
-            "market_cap_change_percentage_24h": 0.28243,
-            "price_change_24h_in_currency": {
-                "usd": -0.007389872916375051
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.64016
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.32651
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 8.61339
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 10.16421
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -8.4558
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -19.60443
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -14.3147
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -32.906
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 124475
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0.28243
-            },
-            "total_supply": 21000000,
-            "max_supply": 21000000,
-            "circulating_supply": 19505633.865142018,
-            "last_updated": "2023-06-27T11:41:31.826Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:41:31.826Z"
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+      "small": "https://assets.coingecko.com/coins/images/12645/small/AAVE.png?1601374110",
+      "large": "https://assets.coingecko.com/coins/images/12645/large/AAVE.png?1601374110"
     },
-    {
-        "id": "balancer",
-        "symbol": "bal",
-        "name": "Balancer",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xba100000625a3754423978a60c9317c58a424e3d",
-            "near-protocol": "ba100000625a3754423978a60c9317c58a424e3d.factory.bridge.near",
-            "xdai": "0x7ef541e2a22058048904fe5744f9c7e4c57af717",
-            "polygon-zkevm": "0x120ef59b80774f02211563834d8e3b72cb1649d6",
-            "avalanche": "0x8239a6b877804206c7799028232a7188da487cec",
-            "huobi-token": "0x045de15ca76e76426e8fc7cba8392a3138078d0f",
-            "polygon-pos": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
-            "harmony-shard-0": "0xdc5f76104d0b8d2bf2c2bbe06cdfe17004e9010f",
-            "arbitrum-one": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
-            "energi": "0x9b817c6e9a38e604606aea3ad6ed271ce8eaa9d6",
-            "optimistic-ethereum": "0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xba100000625a3754423978a60c9317c58a424e3d"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "ba100000625a3754423978a60c9317c58a424e3d.factory.bridge.near"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0x7ef541e2a22058048904fe5744f9c7e4c57af717"
-            },
-            "polygon-zkevm": {
-                "decimal_place": 18,
-                "contract_address": "0x120ef59b80774f02211563834d8e3b72cb1649d6"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0x8239a6b877804206c7799028232a7188da487cec"
-            },
-            "huobi-token": {
-                "decimal_place": 18,
-                "contract_address": "0x045de15ca76e76426e8fc7cba8392a3138078d0f"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0xdc5f76104d0b8d2bf2c2bbe06cdfe17004e9010f"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0x9b817c6e9a38e604606aea3ad6ed271ce8eaa9d6"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Avalanche Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Optimism Ecosystem",
-            "Harmony Ecosystem",
-            "Ethereum Ecosystem",
-            "Arbitrum Ecosystem",
-            "Polygon Ecosystem",
-            "Near Protocol Ecosystem",
-            "Automated Market Maker (AMM)",
-            "Yield Farming",
-            "Governance",
-            "Exchange-based Tokens",
-            "Decentralized Finance (DeFi)",
-            "Decentralized Exchange (DEX)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Balancer is a non-custodial portfolio manager, liquidity provider, and price sensor\r\n\r\nThe Balancer Protocol Governance Token (BAL) are distributed to Liquidity Providers of Balancer. BALs are a key way of decentralizing the governance of the protocol such that it can remain resilient over time, protected from the failure of any single stakeholder. \r\n\r\nThe proposed amount of distributed BALs to liquidity providers is 145,000 per week, or approximately 7.5M per year. This means in the first year of BAL’s existence there would be 30% supply inflation off the initially allocated supply of 25M tokens. This high rate of supply inflation is meant to kickstart the distribution of governance rights of the protocol out to those who earn it."
-        },
-        "links": {
-            "homepage": [
-                "https://balancer.finance/",
-                "http://balancer.exchange/",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xba100000625a3754423978a60c9317c58a424e3D",
-                "https://ethplorer.io/address/0xba100000625a3754423978a60c9317c58a424e3d",
-                "https://arbiscan.io/token/0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
-                "https://polygonscan.com/token/0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
-                "https://explorer.energi.network/token/0x9b817c6e9a38e604606aea3ad6ed271ce8eaa9d6",
-                "https://optimistic.etherscan.io/token/0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921",
-                "https://nearblocks.io/token/ba100000625a3754423978a60c9317c58a424e3d.factory.bridge.near",
-                "https://blockscout.com/xdai/mainnet/token/0x7eF541E2a22058048904fE5744f9c7E4C57AF717/token-transfers",
-                "https://zkevm.polygonscan.com/token/0x120eF59b80774F02211563834d8E3b72cb1649d6",
-                "https://snowtrace.io/token/0x8239a6b877804206c7799028232a7188da487cec"
-            ],
-            "official_forum_url": [
-                "https://forum.balancer.finance/",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/ARJWaeF",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://balancer.finance/blog-feed/",
-                "https://medium.com/balancer-protocol"
-            ],
-            "twitter_screen_name": "Balancer",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/balancer-labs/balancer-core",
-                    "https://github.com/balancer-labs/balancer-exchange",
-                    "https://github.com/balancer-labs/pool-management",
-                    "https://github.com/balancer-labs/balancer-sor"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1592792958",
-            "small": "https://assets.coingecko.com/coins/images/11683/small/Balancer.png?1592792958",
-            "large": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1592792958"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xba100000625a3754423978a60c9317c58a424e3d",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 33700,
-        "market_cap_rank": 172,
-        "coingecko_rank": 166,
-        "coingecko_score": 39.975,
-        "developer_score": 60.667,
-        "community_score": 7.225,
-        "liquidity_score": 44.45,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 4.68
-            },
-            "total_value_locked": {
-                "usd": 1052789756
-            },
-            "mcap_to_tvl_ratio": 0.19,
-            "fdv_to_tvl_ratio": 0.43,
-            "roi": null,
-            "ath": {
-                "usd": 74.45
-            },
-            "ath_change_percentage": {
-                "usd": -93.70134
-            },
-            "ath_date": {
-                "usd": "2021-05-04T13:35:02.939Z"
-            },
-            "atl": {
-                "usd": 3.66
-            },
-            "atl_change_percentage": {
-                "usd": 28.27392
-            },
-            "atl_date": {
-                "usd": "2022-06-18T21:00:00.231Z"
-            },
-            "market_cap": {
-                "usd": 195683306
-            },
-            "market_cap_rank": 172,
-            "fully_diluted_valuation": {
-                "usd": 450225636
-            },
-            "total_volume": {
-                "usd": 3521679
-            },
-            "high_24h": {
-                "usd": 4.79
-            },
-            "low_24h": {
-                "usd": 4.6
-            },
-            "price_change_24h": -0.06314253532826,
-            "price_change_percentage_24h": -1.33194,
-            "price_change_percentage_7d": 6.94895,
-            "price_change_percentage_14d": 4.64993,
-            "price_change_percentage_30d": -11.21716,
-            "price_change_percentage_60d": -24.31163,
-            "price_change_percentage_200d": -22.58455,
-            "price_change_percentage_1y": -13.53605,
-            "market_cap_change_24h": -2751872.863546,
-            "market_cap_change_percentage_24h": -1.38679,
-            "price_change_24h_in_currency": {
-                "usd": -0.06314253532825731
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.65232
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -1.33194
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 6.94895
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 4.64993
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -11.21716
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -24.31163
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -22.58455
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -13.53605
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -2751872.8635453284
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.38679
-            },
-            "total_supply": 57761071.1382759,
-            "max_supply": 96150704,
-            "circulating_supply": 41790351.6546139,
-            "last_updated": "2023-06-27T11:41:37.384Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 64391,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:41:37.384Z"
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+    "sentiment_votes_up_percentage": 80.77,
+    "sentiment_votes_down_percentage": 19.23,
+    "watchlist_portfolio_users": 154866,
+    "market_cap_rank": 42,
+    "coingecko_rank": 70,
+    "coingecko_score": 48.535,
+    "developer_score": 47.114,
+    "community_score": 40.229,
+    "liquidity_score": 61.436,
+    "public_interest_score": 0.106,
+    "market_data": {
+      "current_price": {
+        "usd": 72.79
+      },
+      "total_value_locked": {
+        "usd": 3977167399
+      },
+      "mcap_to_tvl_ratio": 0.27,
+      "fdv_to_tvl_ratio": 0.29,
+      "roi": null,
+      "ath": {
+        "usd": 661.69
+      },
+      "ath_change_percentage": {
+        "usd": -88.98291
+      },
+      "ath_date": {
+        "usd": "2021-05-18T21:19:59.514Z"
+      },
+      "atl": {
+        "usd": 26.02
+      },
+      "atl_change_percentage": {
+        "usd": 180.13133
+      },
+      "atl_date": {
+        "usd": "2020-11-05T09:20:11.928Z"
+      },
+      "market_cap": {
+        "usd": 1055017524
+      },
+      "market_cap_rank": 42,
+      "fully_diluted_valuation": {
+        "usd": 1167496350
+      },
+      "total_volume": {
+        "usd": 121188521
+      },
+      "high_24h": {
+        "usd": 73.07
+      },
+      "low_24h": {
+        "usd": 68.82
+      },
+      "price_change_24h": 3.39,
+      "price_change_percentage_24h": 4.87993,
+      "price_change_percentage_7d": 12.99767,
+      "price_change_percentage_14d": 42.89564,
+      "price_change_percentage_30d": 14.09157,
+      "price_change_percentage_60d": 2.51682,
+      "price_change_percentage_200d": 18.65043,
+      "price_change_percentage_1y": 29.94201,
+      "market_cap_change_24h": 49871890,
+      "market_cap_change_percentage_24h": 4.96166,
+      "price_change_24h_in_currency": {
+        "usd": 3.39
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 1.63644
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 4.87993
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 12.99767
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 42.89564
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 14.09157
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 2.51682
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 18.65043
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 29.94201
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 49871890
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.96166
+      },
+      "total_supply": 16000000,
+      "max_supply": 16000000,
+      "circulating_supply": 14458529.475570453,
+      "last_updated": "2023-07-03T17:46:23.119Z"
     },
-    {
-        "id": "chainlink",
-        "symbol": "link",
-        "name": "Chainlink",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x514910771af9ca656af840dff83e8264ecf986ca",
-            "near-protocol": "514910771af9ca656af840dff83e8264ecf986ca.factory.bridge.near",
-            "xdai": "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2",
-            "binance-smart-chain": "0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd",
-            "polygon-pos": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
-            "huobi-token": "0x9e004545c59d359f6b7bfb06a26390b087717b42",
-            "optimistic-ethereum": "0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6",
-            "harmony-shard-0": "0x218532a12a389a4a92fc0c5fb22901d1c19198aa",
-            "avalanche": "0x5947bb275c521040051d82396192181b413227a3",
-            "arbitrum-one": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
-            "sora": "0x008484148dcf23d1b48908393e7a00d5fdc3bf81029a73eeca62a15ebfb1205a",
-            "fantom": "0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8",
-            "milkomeda-cardano": "0xf390830df829cf22c53c8840554b98eafc5dcbc2",
-            "energi": "0x68ca48ca2626c415a89756471d4ade2cc9034008",
-            "osmosis": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x514910771af9ca656af840dff83e8264ecf986ca"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "514910771af9ca656af840dff83e8264ecf986ca.factory.bridge.near"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39"
-            },
-            "huobi-token": {
-                "decimal_place": 18,
-                "contract_address": "0x9e004545c59d359f6b7bfb06a26390b087717b42"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0x218532a12a389a4a92fc0c5fb22901d1c19198aa"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0x5947bb275c521040051d82396192181b413227a3"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4"
-            },
-            "sora": {
-                "decimal_place": 18,
-                "contract_address": "0x008484148dcf23d1b48908393e7a00d5fdc3bf81029a73eeca62a15ebfb1205a"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8"
-            },
-            "milkomeda-cardano": {
-                "decimal_place": 18,
-                "contract_address": "0xf390830df829cf22c53c8840554b98eafc5dcbc2"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0x68ca48ca2626c415a89756471d4ade2cc9034008"
-            },
-            "osmosis": {
-                "decimal_place": null,
-                "contract_address": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Harmony Ecosystem",
-            "Optimism Ecosystem",
-            "Ethereum Ecosystem",
-            "Edgeware Ecosystem",
-            "Fantom Ecosystem",
-            "Arbitrum Ecosystem",
-            "Avalanche Ecosystem",
-            "BNB Chain Ecosystem",
-            "Cardano Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Polygon Ecosystem",
-            "Near Protocol Ecosystem",
-            "Solana Ecosystem",
-            "Infrastructure",
-            "Polkadot Ecosystem",
-            "Oracle",
-            "Decentralized Finance (DeFi)",
-            "Business Services",
-            "Smart Contract Platform"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Chainlink is a framework for building Decentralized Oracle Networks (DONs) that bring real-world data onto blockchain networks, enabling the creation of hybrid smart contracts. These DONs provide decentralized services such as Price Feeds, Proof of Reserve, Verifiable Randomness, Keepers, and the ability to connect to any web API. \r\n\r\nIt aims to ensure that the external information (pricing, weather data, event outcomes, etc.) and off-chain computations (randomness, transaction automation, fair ordering, etc.) fed to on-chain smart contracts are reliable and tamper-proof."
-        },
-        "links": {
-            "homepage": [
-                "https://chain.link/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x514910771af9ca656af840dff83e8264ecf986ca",
-                "https://ethplorer.io/address/0x514910771af9ca656af840dff83e8264ecf986ca",
-                "https://arbiscan.io/token/0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
-                "https://explorer.chain.link",
-                "https://blockscout.com/poa/xdai/tokens/0xE2e73A1c69ecF83F464EFCE6A5be353a37cA09b2/token-transfers",
-                "https://bscscan.com/token/0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd",
-                "https://polygonscan.com/token/0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
-                "https://snowtrace.io/token/0x5947bb275c521040051d82396192181b413227a3",
-                "https://nearblocks.io/token/514910771af9ca656af840dff83e8264ecf986ca.factory.bridge.near",
-                "https://scan.meter.io/address/0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8"
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://blog.chain.link/",
-                ""
-            ],
-            "twitter_screen_name": "chainlink",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "chainlinkofficial",
-            "subreddit_url": "https://www.reddit.com/r/Chainlink/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/smartcontractkit/chainlink",
-                    "https://github.com/smartcontractkit/chainlink-ruby"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1547034700",
-            "small": "https://assets.coingecko.com/coins/images/877/small/chainlink-new-logo.png?1547034700",
-            "large": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1547034700"
-        },
-        "country_origin": "",
-        "genesis_date": "2017-09-16",
-        "contract_address": "0x514910771af9ca656af840dff83e8264ecf986ca",
-        "sentiment_votes_up_percentage": 77.42,
-        "sentiment_votes_down_percentage": 22.58,
-        "watchlist_portfolio_users": 380692,
-        "market_cap_rank": 23,
-        "coingecko_rank": 8,
-        "coingecko_score": 62.148,
-        "developer_score": 85.761,
-        "community_score": 45.578,
-        "liquidity_score": 70.956,
-        "public_interest_score": 0.047,
-        "market_data": {
-            "current_price": {
-                "usd": 6.21
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 52.7
-            },
-            "ath_change_percentage": {
-                "usd": -88.21892
-            },
-            "ath_date": {
-                "usd": "2021-05-10T00:13:57.214Z"
-            },
-            "atl": {
-                "usd": 0.148183
-            },
-            "atl_change_percentage": {
-                "usd": 4089.56482
-            },
-            "atl_date": {
-                "usd": "2017-11-29T00:00:00.000Z"
-            },
-            "market_cap": {
-                "usd": 3210263290
-            },
-            "market_cap_rank": 23,
-            "fully_diluted_valuation": {
-                "usd": 6208206270
-            },
-            "total_volume": {
-                "usd": 161781477
-            },
-            "high_24h": {
-                "usd": 6.24
-            },
-            "low_24h": {
-                "usd": 6.03
-            },
-            "price_change_24h": 0.04649168,
-            "price_change_percentage_24h": 0.75432,
-            "price_change_percentage_7d": 22.73704,
-            "price_change_percentage_14d": 18.40475,
-            "price_change_percentage_30d": -4.59332,
-            "price_change_percentage_60d": -12.65565,
-            "price_change_percentage_200d": -11.50934,
-            "price_change_percentage_1y": -10.57046,
-            "market_cap_change_24h": 20285235,
-            "market_cap_change_percentage_24h": 0.63591,
-            "price_change_24h_in_currency": {
-                "usd": 0.04649168
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.27499
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.75432
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 22.73704
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 18.40475
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -4.59332
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -12.65565
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -11.50934
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -10.57046
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 20285235
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0.63591
-            },
-            "total_supply": 1000000000,
-            "max_supply": 1000000000,
-            "circulating_supply": 517099972.2305644,
-            "last_updated": "2023-06-27T11:41:17.372Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 41366,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:41:17.372Z"
+    "public_interest_stats": {
+      "alexa_rank": 15890,
+      "bing_matches": null
     },
-    {
-        "id": "convex-finance",
-        "symbol": "cvx",
-        "name": "Convex Finance",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Metagovernance",
-            "Ethereum Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Yield Aggregator"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Convex is a protocol that simplifies Curve boosting experience in order to maximize yields. Convex allows Curve liquidity providers to earn trading fees and claim boosted CRV without locking CRV themselves. Liquidity providers can receive boosted CRV and liquidity mining rewards with minimal effort.\r\nIf you would like to stake CRV, Convex lets users receive trading fees as well as a share of boosted CRV received by liquidity providers. This allows for a better balance between liquidity providers and CRV stakers as well as better capital efficiency.\r\n\r\nCurve liquidity providers can deposit their LP tokens into Convex to maximize their CRV earnings with a more efficient boost.\r\n\r\nCurve DAO token stakers will be able to earn additional boosted CRV and CVX tokens through the protocol.\r\n\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://www.convexfinance.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
-                "https://ethplorer.io/address/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/WHwgFwRG6h",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://convexfinance.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "convexfinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "convexEthChat",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/convex-eth/platform"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328",
-            "small": "https://assets.coingecko.com/coins/images/15585/small/convex.png?1621256328",
-            "large": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1621256328"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 29329,
-        "market_cap_rank": 122,
-        "coingecko_rank": 207,
-        "coingecko_score": 36.849,
-        "developer_score": 46.524,
-        "community_score": 9.123,
-        "liquidity_score": 42.507,
-        "public_interest_score": 0.008,
-        "market_data": {
-            "current_price": {
-                "usd": 3.64
-            },
-            "total_value_locked": {
-                "usd": 3019765863
-            },
-            "mcap_to_tvl_ratio": 0.09,
-            "fdv_to_tvl_ratio": 0.12,
-            "roi": null,
-            "ath": {
-                "usd": 60.09
-            },
-            "ath_change_percentage": {
-                "usd": -93.94093
-            },
-            "ath_date": {
-                "usd": "2022-01-01T18:04:03.030Z"
-            },
-            "atl": {
-                "usd": 1.9
-            },
-            "atl_change_percentage": {
-                "usd": 91.32876
-            },
-            "atl_date": {
-                "usd": "2021-07-20T13:17:29.183Z"
-            },
-            "market_cap": {
-                "usd": 285004579
-            },
-            "market_cap_rank": 122,
-            "fully_diluted_valuation": {
-                "usd": 363792286
-            },
-            "total_volume": {
-                "usd": 2787987
-            },
-            "high_24h": {
-                "usd": 3.72
-            },
-            "low_24h": {
-                "usd": 3.59
-            },
-            "price_change_24h": -0.0365717622553,
-            "price_change_percentage_24h": -0.99443,
-            "price_change_percentage_7d": 5.06831,
-            "price_change_percentage_14d": 4.57801,
-            "price_change_percentage_30d": -19.35075,
-            "price_change_percentage_60d": -31.63252,
-            "price_change_percentage_200d": -7.65216,
-            "price_change_percentage_1y": -22.22309,
-            "market_cap_change_24h": -3266503.250398,
-            "market_cap_change_percentage_24h": -1.13314,
-            "price_change_24h_in_currency": {
-                "usd": -0.03657176225529879
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.2426
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.99443
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 5.06831
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 4.57801
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -19.35075
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -31.63252
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -7.65216
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -22.22309
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -3266503.2503985763
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.13314
-            },
-            "total_supply": 98458715.4613984,
-            "max_supply": 100000000,
-            "circulating_supply": 78342667.06057651,
-            "last_updated": "2023-06-27T11:42:28.124Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:42:28.124Z"
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:23.119Z"
+  },
+  {
+    "id": "across-protocol",
+    "symbol": "acx",
+    "name": "Across Protocol",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+      "optimistic-ethereum": "0xff733b2a3557a7ed6697007ab5d11b79fdd1b76b",
+      "arbitrum-one": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
+      "boba": "0x96821b258955587069f680729cd77369c0892b40",
+      "polygon-pos": "0xf328b73b6c685831f238c30a23fc19140cb4d8fc"
     },
-    {
-        "id": "cow-protocol",
-        "symbol": "cow",
-        "name": "CoW Protocol",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
-            "xdai": "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Decentralized Exchange (DEX)",
-            "MEV Protection",
-            "Ethereum Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Gnosis Chain Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "COW token allows its holders the right to govern and curate the infrastructure of the CoW Protocol ecosystem through the CowDAO. Additionally, COW token holders receive fee discounts when trading on CowSwap & some other perks."
-        },
-        "links": {
-            "homepage": [
-                "https://cow.fi",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-                "https://ethplorer.io/address/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
-                "https://blockscout.com/xdai/mainnet/token/0x177127622c4A00F3d409B75571e12cB3c8973d3c/token-transfers",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/cowprotocol",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/@cow-protocol",
-                ""
-            ],
-            "twitter_screen_name": "CoWSwap",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/gnosis/cow-token/"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/24384/thumb/cow.png?1660960589",
-            "small": "https://assets.coingecko.com/coins/images/24384/small/cow.png?1660960589",
-            "large": "https://assets.coingecko.com/coins/images/24384/large/cow.png?1660960589"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 2845,
-        "market_cap_rank": 912,
-        "coingecko_rank": 626,
-        "coingecko_score": 25.574,
-        "developer_score": 50.117,
-        "community_score": 4.344,
-        "liquidity_score": 0.028,
-        "public_interest_score": 0.002,
-        "market_data": {
-            "current_price": {
-                "usd": 0.073754
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 2.22
-            },
-            "ath_change_percentage": {
-                "usd": -96.67453
-            },
-            "ath_date": {
-                "usd": "2022-03-28T16:24:17.921Z"
-            },
-            "atl": {
-                "usd": 0.03987045
-            },
-            "atl_change_percentage": {
-                "usd": 85.10177
-            },
-            "atl_date": {
-                "usd": "2022-11-09T18:32:42.225Z"
-            },
-            "market_cap": {
-                "usd": 11038088
-            },
-            "market_cap_rank": 912,
-            "fully_diluted_valuation": {
-                "usd": 73764062
-            },
-            "total_volume": {
-                "usd": 6157.82
-            },
-            "high_24h": {
-                "usd": 0.076148
-            },
-            "low_24h": {
-                "usd": 0.073355
-            },
-            "price_change_24h": -0.0023937040736498,
-            "price_change_percentage_24h": -3.1435,
-            "price_change_percentage_7d": 7.87603,
-            "price_change_percentage_14d": 7.0789,
-            "price_change_percentage_30d": -2.24115,
-            "price_change_percentage_60d": -7.21067,
-            "price_change_percentage_200d": 0.54598,
-            "price_change_percentage_1y": -21.81895,
-            "market_cap_change_24h": -355964.5136389,
-            "market_cap_change_percentage_24h": -3.12413,
-            "price_change_24h_in_currency": {
-                "usd": -0.002393704073649736
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.08909
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -3.1435
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 7.87603
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 7.0789
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -2.24115
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -7.21067
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 0.54598
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -21.81895
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -355964.5136389416
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -3.12413
-            },
-            "total_supply": 1000000000,
-            "max_supply": 1000000000,
-            "circulating_supply": 149640461.824951,
-            "last_updated": "2023-06-27T11:42:13.229Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:42:13.229Z"
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xff733b2a3557a7ed6697007ab5d11b79fdd1b76b"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d"
+      },
+      "boba": {
+        "decimal_place": 18,
+        "contract_address": "0x96821b258955587069f680729cd77369c0892b40"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0xf328b73b6c685831f238c30a23fc19140cb4d8fc"
+      }
     },
-    {
-        "id": "curve-dao-token",
-        "symbol": "crv",
-        "name": "Curve DAO",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xd533a949740bb3306d119cc777fa900ba034cd52",
-            "polygon-pos": "0x172370d5cd63279efa6d502dab29171933a610af",
-            "fantom": "0x1e4f97b9f9f913c46f1632781732927b9019c68b",
-            "arbitrum-one": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
-            "sora": "0x002ead91a2de57b8855b53d4a62c25277073fd7f65f7e5e79f4936ed747fcad0",
-            "energi": "0xd3319eaf3c4743ac75aace77befcfa445ed6e69e",
-            "optimistic-ethereum": "0x0994206dfe8de6ec6920ff4d779b0d950605fb53"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xd533a949740bb3306d119cc777fa900ba034cd52"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x172370d5cd63279efa6d502dab29171933a610af"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x1e4f97b9f9f913c46f1632781732927b9019c68b"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978"
-            },
-            "sora": {
-                "decimal_place": 18,
-                "contract_address": "0x002ead91a2de57b8855b53d4a62c25277073fd7f65f7e5e79f4936ed747fcad0"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0xd3319eaf3c4743ac75aace77befcfa445ed6e69e"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x0994206dfe8de6ec6920ff4d779b0d950605fb53"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Optimism Ecosystem",
-            "Fantom Ecosystem",
-            "Ethereum Ecosystem",
-            "Arbitrum Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Polygon Ecosystem",
-            "Exchange-based Tokens",
-            "Decentralized Exchange (DEX)",
-            "Automated Market Maker (AMM)",
-            "Yield Farming",
-            "Governance",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Similar to Uniswap, Curve Finance is an Automated Market Maker (AMM) based Decentralised Exchange (DEX). Unlike Uniswap, its main focus is only to swap between assets that are supposed to have the same value. This is useful in the DeFi ecosystem as there are plenty of wrapped tokens and synthetic tokens that aim to mimic the price of the real underlying asset. \r\n\r\nFor example, one of the biggest pools is 3CRV, which is a stablecoin pool consisting of DAI, USDT, and USDC. Their ratio in the pool will be based on the supply and demand of the market. Depositing a coin with a lesser ratio will yield the user a higher percentage of the pool. As such when the ratio is heavily tilted to one of the coins, it may serve as a good chance to arbitrage.\r\n\r\nCurve Finance also supports yield-bearing tokens. For example, it collaborated with Yearn Finance to release yUSD pools that consisted of yDAI, yUSDT, yUSDC and yTUSD. Users that participated in this pool will not only have yield from the underlying yield-bearing tokens, but also the swap fees generated by the Curve pool. Including the yield farming rewards in terms of CRV tokens, liquidity providers of the pool actually have three sources of yield. "
-        },
-        "links": {
-            "homepage": [
-                "https://www.curve.fi/",
-                "https://curve.eth.link/",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xd533a949740bb3306d119cc777fa900ba034cd52",
-                "https://ethplorer.io/address/0xd533a949740bb3306d119cc777fa900ba034cd52",
-                "https://polygonscan.com/token/0x172370d5cd63279efa6d502dab29171933a610af",
-                "https://arbiscan.io/token/0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
-                "https://ftmscan.com/token/0x1e4f97b9f9f913c46f1632781732927b9019c68b",
-                "https://scan.meter.io/address/0x1e4f97b9f9f913c46f1632781732927b9019c68b",
-                "https://ftmscan.com/address/0x1e4f97b9f9f913c46f1632781732927b9019c68b",
-                "https://explorer.energi.network/token/0xd3319eaf3c4743ac75aace77befcfa445ed6e69e",
-                "https://optimistic.etherscan.io/token/0x0994206dfE8De6Ec6920FF4D779B0d950605Fb53",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/9uEHakc",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "curvefinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "curvefi",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/curvefi/curve-contract",
-                    "https://github.com/curvefi/curve-vue"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/12124/thumb/Curve.png?1597369484",
-            "small": "https://assets.coingecko.com/coins/images/12124/small/Curve.png?1597369484",
-            "large": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1597369484"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
-        "sentiment_votes_up_percentage": 66.67,
-        "sentiment_votes_down_percentage": 33.33,
-        "watchlist_portfolio_users": 92489,
-        "market_cap_rank": 73,
-        "coingecko_rank": 111,
-        "coingecko_score": 44.36,
-        "developer_score": 61.576,
-        "community_score": 10.746,
-        "liquidity_score": 59.03,
-        "public_interest_score": 0.035,
-        "market_data": {
-            "current_price": {
-                "usd": 0.685206
-            },
-            "total_value_locked": {
-                "usd": 3776348326
-            },
-            "mcap_to_tvl_ratio": 0.16,
-            "fdv_to_tvl_ratio": 0.6,
-            "roi": null,
-            "ath": {
-                "usd": 15.37
-            },
-            "ath_change_percentage": {
-                "usd": -95.54693
-            },
-            "ath_date": {
-                "usd": "2020-08-14T00:00:00.000Z"
-            },
-            "atl": {
-                "usd": 0.331577
-            },
-            "atl_change_percentage": {
-                "usd": 106.44655
-            },
-            "atl_date": {
-                "usd": "2020-11-05T13:09:50.181Z"
-            },
-            "market_cap": {
-                "usd": 588655324
-            },
-            "market_cap_rank": 73,
-            "fully_diluted_valuation": {
-                "usd": 2263459738
-            },
-            "total_volume": {
-                "usd": 41491605
-            },
-            "high_24h": {
-                "usd": 0.697443
-            },
-            "low_24h": {
-                "usd": 0.667724
-            },
-            "price_change_24h": -0.006899985481646001,
-            "price_change_percentage_24h": -0.99696,
-            "price_change_percentage_7d": 9.17053,
-            "price_change_percentage_14d": 4.78598,
-            "price_change_percentage_30d": -20.03566,
-            "price_change_percentage_60d": -26.93707,
-            "price_change_percentage_200d": 2.93957,
-            "price_change_percentage_1y": -12.99407,
-            "market_cap_change_24h": -5970283.228452,
-            "market_cap_change_percentage_24h": -1.00404,
-            "price_change_24h_in_currency": {
-                "usd": -0.006899985481646387
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.13474
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.99696
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 9.17053
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 4.78598
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -20.03566
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -26.93707
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 2.93957
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -12.99407
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -5970283.228451848
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.00404
-            },
-            "total_supply": 1971168048.72813,
-            "max_supply": 3303030299,
-            "circulating_supply": 859015223,
-            "last_updated": "2023-06-27T11:41:29.522Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 14362,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:41:29.522Z"
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Polygon Ecosystem", "Arbitrum Ecosystem", "Optimism Ecosystem", "Ethereum Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Across is an optimistic cross-chain bridge secured by UMA’s optimistic oracle. It is optimized for capital efficiency with a single liquidity pool, a competitive relayer landscape, and a no-slippage fee model. "
     },
-    {
-        "id": "dai",
-        "symbol": "dai",
-        "name": "Dai",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x6b175474e89094c44da98b954eedeac495271d0f",
-            "polygon-zkevm": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
-            "kava": "0x765277eebeca2e31912c9946eae1021199b39c61",
-            "binance-smart-chain": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
-            "polygon-pos": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
-            "optimistic-ethereum": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-            "metis-andromeda": "0x4651b38e7ec14bb3db731369bfe5b08f2466bd0a",
-            "harmony-shard-0": "0xef977d2f931c1978db5f6747666fa1eacb0d0339",
-            "avalanche": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-            "arbitrum-one": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-            "sora": "0x0200060000000000000000000000000000000000000000000000000000000000",
-            "moonriver": "0x80a16016cc4a2e6a2caca8a4a498b1699ff0f844",
-            "aurora": "0xe3520349f477a5f6eb06107066048508498a291b",
-            "cronos": "0xf2001b145b43032aaf5ee2884e456ccd805f677d",
-            "fantom": "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e",
-            "moonbeam": "0x765277eebeca2e31912c9946eae1021199b39c61",
-            "syscoin": "0xefaeee334f0fd1712f9a8cc375f427d9cdd40d73",
-            "milkomeda-cardano": "0x639a647fbe20b6c8ac19e48e2de44ea792c62c5c",
-            "energi": "0x0ee5893f434017d8881750101ea2f7c49c0eb503",
-            "cosmos": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-            "astar": "0x6de33698e9e9b787e09d3bd7771ef63557e148bb",
-            "arbitrum-nova": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-            "velas": "0xe3f5a90f9cb311505cd691a46596599aa1a0ad7d",
-            "klay-token": "0x078db7827a5531359f6cb63f62cfa20183c4f10c",
-            "xdai": "0x44fa8e6f47987339850636f88629646662444217",
-            "hydra": "abc2cd00700e06922bcf30fe0ad648507113cc56",
-            "near-protocol": "6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f"
-            },
-            "polygon-zkevm": {
-                "decimal_place": 18,
-                "contract_address": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4"
-            },
-            "kava": {
-                "decimal_place": 18,
-                "contract_address": "0x765277eebeca2e31912c9946eae1021199b39c61"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
-            },
-            "metis-andromeda": {
-                "decimal_place": 18,
-                "contract_address": "0x4651b38e7ec14bb3db731369bfe5b08f2466bd0a"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0xef977d2f931c1978db5f6747666fa1eacb0d0339"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
-            },
-            "sora": {
-                "decimal_place": 18,
-                "contract_address": "0x0200060000000000000000000000000000000000000000000000000000000000"
-            },
-            "moonriver": {
-                "decimal_place": 18,
-                "contract_address": "0x80a16016cc4a2e6a2caca8a4a498b1699ff0f844"
-            },
-            "aurora": {
-                "decimal_place": 18,
-                "contract_address": "0xe3520349f477a5f6eb06107066048508498a291b"
-            },
-            "cronos": {
-                "decimal_place": 18,
-                "contract_address": "0xf2001b145b43032aaf5ee2884e456ccd805f677d"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e"
-            },
-            "moonbeam": {
-                "decimal_place": 18,
-                "contract_address": "0x765277eebeca2e31912c9946eae1021199b39c61"
-            },
-            "syscoin": {
-                "decimal_place": 18,
-                "contract_address": "0xefaeee334f0fd1712f9a8cc375f427d9cdd40d73"
-            },
-            "milkomeda-cardano": {
-                "decimal_place": 18,
-                "contract_address": "0x639a647fbe20b6c8ac19e48e2de44ea792c62c5c"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0x0ee5893f434017d8881750101ea2f7c49c0eb503"
-            },
-            "cosmos": {
-                "decimal_place": 0,
-                "contract_address": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
-            },
-            "astar": {
-                "decimal_place": 18,
-                "contract_address": "0x6de33698e9e9b787e09d3bd7771ef63557e148bb"
-            },
-            "arbitrum-nova": {
-                "decimal_place": 18,
-                "contract_address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
-            },
-            "velas": {
-                "decimal_place": 18,
-                "contract_address": "0xe3f5a90f9cb311505cd691a46596599aa1a0ad7d"
-            },
-            "klay-token": {
-                "decimal_place": 18,
-                "contract_address": "0x078db7827a5531359f6cb63f62cfa20183c4f10c"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0x44fa8e6f47987339850636f88629646662444217"
-            },
-            "hydra": {
-                "decimal_place": null,
-                "contract_address": "abc2cd00700e06922bcf30fe0ad648507113cc56"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Harmony Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Velas Ecosystem",
-            "Optimism Ecosystem",
-            "Arbitrum Nova Ecosystem",
-            "Metis Ecosystem",
-            "Cronos Ecosystem",
-            "Ethereum Ecosystem",
-            "Moonbeam Ecosystem",
-            "Near Protocol Ecosystem",
-            "Fantom Ecosystem",
-            "Arbitrum Ecosystem",
-            "Moonriver Ecosystem",
-            "Avalanche Ecosystem",
-            "BNB Chain Ecosystem",
-            "Polygon Ecosystem",
-            "USD Stablecoin",
-            "Decentralized Finance (DeFi)",
-            "Stablecoins"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "MakerDAO has launched Multi-collateral DAI (MCD). This token refers to the new DAI that is collaterized by multiple assets.\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://makerdao.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f",
-                "https://ethplorer.io/address/0x6b175474e89094c44da98b954eedeac495271d0f",
-                "https://blockchair.com/ethereum/erc-20/token/0x6b175474e89094c44da98b954eedeac495271d0f",
-                "https://arbiscan.io/token/0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
-                "https://polygonscan.com/token/0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
-                "https://bscscan.com/token/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
-                "https://snowtrace.io/token/0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-                "https://avascan.info/blockchain/c/address/0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
-                "https://explorer.mainnet.aurora.dev/token/0xe3520349f477a5f6eb06107066048508498a291b/token-transfers",
-                "https://moonriver.moonscan.io/token/0x80a16016cc4a2e6a2caca8a4a498b1699ff0f844"
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "MakerDAO",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "makerdaoOfficial",
-            "subreddit_url": "https://www.reddit.com/r/MakerDAO",
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/9956/thumb/Badge_Dai.png?1687143508",
-            "small": "https://assets.coingecko.com/coins/images/9956/small/Badge_Dai.png?1687143508",
-            "large": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1687143508"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-        "sentiment_votes_up_percentage": 40,
-        "sentiment_votes_down_percentage": 60,
-        "watchlist_portfolio_users": 43412,
-        "market_cap_rank": 19,
-        "coingecko_rank": 165,
-        "coingecko_score": 40.022,
-        "developer_score": 0,
-        "community_score": 41.386,
-        "liquidity_score": 69.787,
-        "public_interest_score": 0.018,
-        "market_data": {
-            "current_price": {
-                "usd": 0.999699
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1.22
-            },
-            "ath_change_percentage": {
-                "usd": -17.98555
-            },
-            "ath_date": {
-                "usd": "2020-03-13T03:02:50.373Z"
-            },
-            "atl": {
-                "usd": 0.88196
-            },
-            "atl_change_percentage": {
-                "usd": 13.34974
-            },
-            "atl_date": {
-                "usd": "2023-03-11T07:50:50.514Z"
-            },
-            "market_cap": {
-                "usd": 4416087697
-            },
-            "market_cap_rank": 19,
-            "fully_diluted_valuation": {
-                "usd": 4416087697
-            },
-            "total_volume": {
-                "usd": 130766494
-            },
-            "high_24h": {
-                "usd": 1.003
-            },
-            "low_24h": {
-                "usd": 0.996457
-            },
-            "price_change_24h": 5.97077e-7,
-            "price_change_percentage_24h": 0.00006,
-            "price_change_percentage_7d": -0.03592,
-            "price_change_percentage_14d": -0.03054,
-            "price_change_percentage_30d": -0.09896,
-            "price_change_percentage_60d": -0.17301,
-            "price_change_percentage_200d": 0.00477,
-            "price_change_percentage_1y": -0.16541,
-            "market_cap_change_24h": -24206938.43422,
-            "market_cap_change_percentage_24h": -0.54517,
-            "price_change_24h_in_currency": {
-                "usd": 5.97077e-7
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.13218
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.00006
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -0.03592
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -0.03054
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -0.09896
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -0.17301
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 0.00477
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -0.16541
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -24206938.434223175
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.54517
-            },
-            "total_supply": 4417416658.0911,
-            "max_supply": 4417416658.0911,
-            "circulating_supply": 4417416658.0911,
-            "last_updated": "2023-06-27T11:40:00.260Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 30241,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:40:00.260Z"
+    "links": {
+      "homepage": ["https://across.to/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+        "https://ethplorer.io/address/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+        "https://optimistic.etherscan.io/token/0xFf733b2A3557a7ed6697007ab5D11B79FdD1b76B",
+        "https://arbiscan.io/token/0x53691596d1bce8cea565b84d4915e69e03d9c99d",
+        "https://blockexplorer.boba.network/tokens/0x96821b258955587069f680729cd77369c0892b40",
+        "https://polygonscan.com/token/0xf328b73b6c685831f238c30a23fc19140cb4d8fc",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["https://forum.across.to/", "", ""],
+      "chat_url": ["https://discord.com/invite/sKSkhTtu8s", "https://medium.com/across-protocol", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "AcrossProtocol",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/across-protocol"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "daohaus",
-        "symbol": "haus",
-        "name": "DAOhaus",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
-            "xdai": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xf2051511b9b121394fa75b8f7d4e7424337af687"
-            },
-            "xdai": {
-                "decimal_place": 35,
-                "contract_address": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Governance"
-        ],
-        "public_notice": null,
-        "additional_notices": [
-            "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
-        ],
-        "description": {
-            "en": "This HAUS doesn't build itself\r\nIt takes a community, and HausDAO is the community of contributors working together directly to design, build, and communicate the actual product."
-        },
-        "links": {
-            "homepage": [
-                "https://daohaus.club/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xf2051511b9b121394fa75b8f7d4e7424337af687",
-                "https://ethplorer.io/address/0xf2051511b9b121394fa75b8f7d4e7424337af687",
-                "https://blockscout.com/xdai/mainnet/tokens/0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb/token-transfers",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/daohaus",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/daohaus-club/",
-                ""
-            ],
-            "twitter_screen_name": "nowdaoit",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/HausDAO/pokemol-web"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14551/thumb/jN3kkqke_400x400.png?1616990048",
-            "small": "https://assets.coingecko.com/coins/images/14551/small/jN3kkqke_400x400.png?1616990048",
-            "large": "https://assets.coingecko.com/coins/images/14551/large/jN3kkqke_400x400.png?1616990048"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 926,
-        "market_cap_rank": 2151,
-        "coingecko_rank": 355,
-        "coingecko_score": 31.097,
-        "developer_score": 70.211,
-        "community_score": 8.208,
-        "liquidity_score": 1,
-        "public_interest_score": 0.003,
-        "market_data": {
-            "current_price": {
-                "usd": 0.692533
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 85.61
-            },
-            "ath_change_percentage": {
-                "usd": -99.19165
-            },
-            "ath_date": {
-                "usd": "2021-03-30T15:56:59.843Z"
-            },
-            "atl": {
-                "usd": 0.654852
-            },
-            "atl_change_percentage": {
-                "usd": 5.67943
-            },
-            "atl_date": {
-                "usd": "2023-06-25T09:19:32.756Z"
-            },
-            "market_cap": {
-                "usd": 691883
-            },
-            "market_cap_rank": 2151,
-            "fully_diluted_valuation": {
-                "usd": 691883
-            },
-            "total_volume": {
-                "usd": 368.97
-            },
-            "high_24h": {
-                "usd": 0.880932
-            },
-            "low_24h": {
-                "usd": 0.674822
-            },
-            "price_change_24h": -0.186533254710912,
-            "price_change_percentage_24h": -21.21948,
-            "price_change_percentage_7d": -51.61563,
-            "price_change_percentage_14d": -52.69788,
-            "price_change_percentage_30d": -50.48546,
-            "price_change_percentage_60d": -74.42041,
-            "price_change_percentage_200d": -78.46315,
-            "price_change_percentage_1y": -81.77666,
-            "market_cap_change_24h": -187079.531093069,
-            "market_cap_change_percentage_24h": -21.28413,
-            "price_change_24h_in_currency": {
-                "usd": -0.18653325471091176
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.06236
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -21.21948
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -51.61563
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -52.69788
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -50.48546
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -74.42041
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -78.46315
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -81.77666
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -187079.53109306865
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -21.28413
-            },
-            "total_supply": 1000000,
-            "max_supply": 1000000,
-            "circulating_supply": 1000000,
-            "last_updated": "2023-06-27T11:42:11.998Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:42:11.998Z"
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/28161/thumb/across-200x200.png?1668168201",
+      "small": "https://assets.coingecko.com/coins/images/28161/small/across-200x200.png?1668168201",
+      "large": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1668168201"
     },
-    {
-        "id": "diversified-staked-eth",
-        "symbol": "dseth",
-        "name": "Diversified Staked ETH",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x341c05c0e9b33c0e38d64de76516b2ce970bb3be"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x341c05c0e9b33c0e38d64de76516b2ce970bb3be"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": "Anyone can mint new tokens, please proceed with caution.",
-        "additional_notices": [],
-        "description": {
-            "en": "The Diversified Staked ETH Index (dsETH) is an index token of the leading Ethereum liquid staking tokens. Along with providing a source of diversified staking yield, dsETH strengthens the Ethereum network with weightings that favor decentralized liquid staking protocols. "
-        },
-        "links": {
-            "homepage": [
-                "https://indexcoop.com",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x341c05c0e9b33c0e38d64de76516b2ce970bb3be",
-                "https://ethplorer.io/address/0x341c05c0e9b33c0e38d64de76516b2ce970bb3be",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://www.linkedin.com/company/index-coop/",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/indexcoop",
-                "https://indexcoop.com/blog",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/IndexCoop/index-protocol"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/28751/thumb/dsETH-logo.png?1673929867",
-            "small": "https://assets.coingecko.com/coins/images/28751/small/dsETH-logo.png?1673929867",
-            "large": "https://assets.coingecko.com/coins/images/28751/large/dsETH-logo.png?1673929867"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x341c05c0e9b33c0e38d64de76516b2ce970bb3be",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 67,
-        "market_cap_rank": 1776,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 1900.42
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 2153.61
-            },
-            "ath_change_percentage": {
-                "usd": -11.75637
-            },
-            "ath_date": {
-                "usd": "2023-04-16T19:25:40.546Z"
-            },
-            "atl": {
-                "usd": 1393.4
-            },
-            "atl_change_percentage": {
-                "usd": 36.38785
-            },
-            "atl_date": {
-                "usd": "2023-03-10T11:26:03.021Z"
-            },
-            "market_cap": {
-                "usd": 1503136
-            },
-            "market_cap_rank": 1776,
-            "fully_diluted_valuation": {
-                "usd": 1503136
-            },
-            "total_volume": {
-                "usd": 14.93
-            },
-            "high_24h": {
-                "usd": 1939.75
-            },
-            "low_24h": {
-                "usd": 1877.64
-            },
-            "price_change_24h": -14.86894294763,
-            "price_change_percentage_24h": -0.77633,
-            "price_change_percentage_7d": 8.29226,
-            "price_change_percentage_14d": 7.63182,
-            "price_change_percentage_30d": 1.45702,
-            "price_change_percentage_60d": -0.03532,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": -8650.96143158,
-            "market_cap_change_percentage_24h": -0.57223,
-            "price_change_24h_in_currency": {
-                "usd": -14.868942947636924
-            },
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.77633
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 8.29226
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 7.63182
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 1.45702
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -0.03532
-            },
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {
-                "usd": -8650.961431577802
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.57223
-            },
-            "total_supply": 790.947996575076,
-            "max_supply": null,
-            "circulating_supply": 790.947996575076,
-            "last_updated": "2023-06-27T02:49:48.966Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T02:49:48.966Z"
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 1626,
+    "market_cap_rank": 958,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 0.04542761
+      },
+      "total_value_locked": {
+        "usd": 47079602
+      },
+      "mcap_to_tvl_ratio": 0.21,
+      "fdv_to_tvl_ratio": 0.96,
+      "roi": null,
+      "ath": {
+        "usd": 0.102523
+      },
+      "ath_change_percentage": {
+        "usd": -55.69323
+      },
+      "ath_date": {
+        "usd": "2023-02-26T17:19:36.011Z"
+      },
+      "atl": {
+        "usd": 0.03440846
+      },
+      "atl_change_percentage": {
+        "usd": 32.01543
+      },
+      "atl_date": {
+        "usd": "2023-06-01T08:30:40.359Z"
+      },
+      "market_cap": {
+        "usd": 9718309
+      },
+      "market_cap_rank": 958,
+      "fully_diluted_valuation": {
+        "usd": 45392146
+      },
+      "total_volume": {
+        "usd": 471755
+      },
+      "high_24h": {
+        "usd": 0.053662
+      },
+      "low_24h": {
+        "usd": 0.04187178
+      },
+      "price_change_24h": -0.007738471970039701,
+      "price_change_percentage_24h": -14.55528,
+      "price_change_percentage_7d": 2.38406,
+      "price_change_percentage_14d": 1.42534,
+      "price_change_percentage_30d": 15.9604,
+      "price_change_percentage_60d": -8.91357,
+      "price_change_percentage_200d": -16.71318,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": -1601812.33040346,
+      "market_cap_change_percentage_24h": -14.15013,
+      "price_change_24h_in_currency": {
+        "usd": -0.007738471970039663
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.84984
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": -14.55528
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 2.38406
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 1.42534
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 15.9604
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -8.91357
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -16.71318
+      },
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {
+        "usd": -1601812.3304034993
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -14.15013
+      },
+      "total_supply": 1000000000,
+      "max_supply": 1000000000,
+      "circulating_supply": 214096702.3679336,
+      "last_updated": "2023-07-03T17:46:50.269Z"
     },
-    {
-        "id": "eden",
-        "symbol": "eden",
-        "name": "EDEN",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "MEV Protection"
-        ],
-        "public_notice": "<a href=\"https://www.coingecko.com/en/coins/archer-dao-governance-token?locale=en\">ARCH</a> is currently undergoing migration to EDEN. For more information, visit https://medium.com/archer-dao/arch-token-migration-915e6af976c6.",
-        "additional_notices": [],
-        "description": {
-            "en": "Eden is a priority transaction network that protects traders from frontrunning, aligns incentives for block producers, and redistributes miner extractable value."
-        },
-        "links": {
-            "homepage": [
-                "https://www.edennetwork.io/",
-                "https://medium.com/edennetwork",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
-                "https://ethplorer.io/address/0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.io/edennetwork",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/archer-dao",
-                ""
-            ],
-            "twitter_screen_name": "edennetwork",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "archerdao",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/eden-network"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/17470/thumb/Iyc0XM5-_400x400.jpg?1628254655",
-            "small": "https://assets.coingecko.com/coins/images/17470/small/Iyc0XM5-_400x400.jpg?1628254655",
-            "large": "https://assets.coingecko.com/coins/images/17470/large/Iyc0XM5-_400x400.jpg?1628254655"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 5878,
-        "market_cap_rank": 1232,
-        "coingecko_rank": 1264,
-        "coingecko_score": 19.387,
-        "developer_score": 0,
-        "community_score": 8.311,
-        "liquidity_score": 27.324,
-        "public_interest_score": 0.002,
-        "market_data": {
-            "current_price": {
-                "usd": 0.03628781
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 9.27
-            },
-            "ath_change_percentage": {
-                "usd": -99.60864
-            },
-            "ath_date": {
-                "usd": "2021-09-08T19:31:10.058Z"
-            },
-            "atl": {
-                "usd": 0
-            },
-            "atl_change_percentage": {
-                "usd": 4.9655951539412735e+35
-            },
-            "atl_date": {
-                "usd": "2021-08-03T18:56:38.176Z"
-            },
-            "market_cap": {
-                "usd": 4445821
-            },
-            "market_cap_rank": 1232,
-            "fully_diluted_valuation": {
-                "usd": 9033695
-            },
-            "total_volume": {
-                "usd": 100965
-            },
-            "high_24h": {
-                "usd": 0.03689274
-            },
-            "low_24h": {
-                "usd": 0.0352069
-            },
-            "price_change_24h": -0.0001601672357723,
-            "price_change_percentage_24h": -0.43944,
-            "price_change_percentage_7d": 4.46878,
-            "price_change_percentage_14d": -2.52267,
-            "price_change_percentage_30d": -9.32828,
-            "price_change_percentage_60d": -45.05269,
-            "price_change_percentage_200d": -36.70831,
-            "price_change_percentage_1y": -65.28007,
-            "market_cap_change_24h": -28062.56962531,
-            "market_cap_change_percentage_24h": -0.62725,
-            "price_change_24h_in_currency": {
-                "usd": -0.000160167235772266
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.18025
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.43944
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 4.46878
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -2.52267
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -9.32828
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -45.05269
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -36.70831
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -65.28007
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -28062.56962530315
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.62725
-            },
-            "total_supply": 145834393.550635,
-            "max_supply": 250000000,
-            "circulating_supply": 123034393.550635,
-            "last_updated": "2023-06-27T11:43:41.149Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:43:41.149Z"
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
     },
-    {
-        "id": "fei-usd",
-        "symbol": "fei",
-        "name": "Fei USD",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x956f47f50a910163d8bf957cf5846d573e7f87ca"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "USD Stablecoin",
-            "Ethereum Ecosystem",
-            "Stablecoins",
-            "Decentralized Finance (DeFi)",
-            "Asset-backed Tokens"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "FEI uses a new kind of stablecoin mechanism called protocol controlled value (PCV). It is more capital-efficient, has a fair distribution, and is fully decentralized. The protocol uses the value it controls to maintain liquid secondary markets.\r\n\r\nFei Labs is the team that created FEI, a highly scalable, decentralized, and reserve-backed stablecoin that can meet DeFi’s needs without relying on centralized assets for collateral, that unlocks next-generation integration potential. Our mission is to be the stable coin of DeFi backed by some of the top minds in the space, including a16z, Nascent, Variant, Coinbase,\r\n\r\nFei v2 launches in late 2021, bringing 1:1 redeemability, TRIBE buybacks/backstop, and algorithmic PCV management: https://medium.com/fei-protocol/introducing-fei-v2-6f56afe7a1b5"
-        },
-        "links": {
-            "homepage": [
-                "https://fei.money/",
-                "https://app.fei.money/",
-                "https://docs.fei.money/"
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/address/0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
-                "https://etherscan.io/token/0x956f47f50a910163d8bf957cf5846d573e7f87ca",
-                "https://ethplorer.io/address/0x956f47f50a910163d8bf957cf5846d573e7f87ca",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/2prhYdQ5jP",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/@fei-protocol",
-                ""
-            ],
-            "twitter_screen_name": "feiprotocol",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "feiprotocol",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14570/thumb/ZqsF51Re_400x400.png?1617082206",
-            "small": "https://assets.coingecko.com/coins/images/14570/small/ZqsF51Re_400x400.png?1617082206",
-            "large": "https://assets.coingecko.com/coins/images/14570/large/ZqsF51Re_400x400.png?1617082206"
-        },
-        "country_origin": "US",
-        "genesis_date": null,
-        "contract_address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 3807,
-        "market_cap_rank": 515,
-        "coingecko_rank": 887,
-        "coingecko_score": 22.298,
-        "developer_score": 0,
-        "community_score": 9.127,
-        "liquidity_score": 32.341,
-        "public_interest_score": 0.001,
-        "market_data": {
-            "current_price": {
-                "usd": 0.986088
-            },
-            "total_value_locked": {
-                "usd": 5.99
-            },
-            "mcap_to_tvl_ratio": 5680813.59,
-            "fdv_to_tvl_ratio": 5723509.33,
-            "roi": null,
-            "ath": {
-                "usd": 1.6
-            },
-            "ath_change_percentage": {
-                "usd": -38.39919
-            },
-            "ath_date": {
-                "usd": "2023-04-23T10:41:30.842Z"
-            },
-            "atl": {
-                "usd": 0.61038
-            },
-            "atl_change_percentage": {
-                "usd": 61.64419
-            },
-            "atl_date": {
-                "usd": "2023-04-09T16:41:35.657Z"
-            },
-            "market_cap": {
-                "usd": 34017973
-            },
-            "market_cap_rank": 515,
-            "fully_diluted_valuation": {
-                "usd": 34273644
-            },
-            "total_volume": {
-                "usd": 46915
-            },
-            "high_24h": {
-                "usd": 1.005
-            },
-            "low_24h": {
-                "usd": 0.944651
-            },
-            "price_change_24h": 0.03906645,
-            "price_change_percentage_24h": 4.12519,
-            "price_change_percentage_7d": -1.80823,
-            "price_change_percentage_14d": 3.82827,
-            "price_change_percentage_30d": -1.0841,
-            "price_change_percentage_60d": -1.30449,
-            "price_change_percentage_200d": 1.55214,
-            "price_change_percentage_1y": -1.38121,
-            "market_cap_change_24h": 1463027,
-            "market_cap_change_percentage_24h": 4.49402,
-            "price_change_24h_in_currency": {
-                "usd": 0.03906645
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.63705
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 4.12519
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -1.80823
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 3.82827
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -1.0841
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -1.30449
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 1.55214
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -1.38121
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 1463027
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 4.49402
-            },
-            "total_supply": 34681949.2288202,
-            "max_supply": 34681949.2288202,
-            "circulating_supply": 34423231.8290477,
-            "last_updated": "2023-06-27T11:44:07.034Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:44:07.034Z"
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:50.269Z"
+  },
+  {
+    "id": "alchemist",
+    "symbol": "mist",
+    "name": "Alchemist",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab"
     },
-    {
-        "id": "flux-dai",
-        "symbol": "fdai",
-        "name": "Flux DAI",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xe2ba8693ce7474900a045757fe0efca900f6530b"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 8,
-                "contract_address": "0xe2ba8693ce7474900a045757fe0efca900f6530b"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [],
-        "public_notice": null,
-        "additional_notices": [
-            "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
-        ],
-        "description": {
-            "en": "What is fDAI?\r\nEach asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fDAI, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets. \r\n\r\nWhat Makes fDAI Unique?\r\nfDAI is minted when users deposit DAI on Flux Finance. By doing so, the user's DAI will become available to borrowers, and the user will earn the DAI supply rate. fDAI increases in value relative to the underlying DAI, meaning users can redeem more assets over time as interest is earned. The interest rate earned by lenders fluctuates and depends on the market's utilization (i.e. the percentage of deposited assets that have been borrowed).\r\n\r\nHistory of fDAI\r\nIn January 2023, Flux was announced as a decentralized lending protocol that can support permissionless cryptoassets alongside permissioned tokens. The protocol was initially developed by Ondo Finance, a software development firm in DeFi, before being sold to Flux Finance.\r\n\r\nFlux is governed by the Ondo DAO, in which ONDO holders vote to upgrade its code and alter its risk parameters. In February 2023, the protocol was initialized and its supported assets and parameters were selected in a genesis vote. fDAI was among the first assets to be selected, alongside fUSDC and fOUSG. Markets for these assets opened shortly after.\r\n\r\nWhat can fDAI be Used For?\r\nBy minting fDAI, users earn interest and gain the ability to use fDAI as collateral. fDAI can be transferred to effect change in ownership. Transferring fDAI means transferring your balance of the underlying DAI inside the Flux Finance protocol. Transfers that would result in negative account liquidity for borrowers on Flux Finance will fail.\r\n\r\nWhat’s Next for fDAI?\r\nAs a permissionless yielding asset, fDAI can in turn be used as collateral at other lending protocols, and offers an alternative settlement option between parties."
-        },
-        "links": {
-            "homepage": [
-                "https://fluxfinance.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xe2bA8693cE7474900A045757fe0efCa900F6530b",
-                "https://ethplorer.io/address/0xe2bA8693cE7474900A045757fe0efCa900F6530b",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/YzhZaFbB92",
-                "https://blog.fluxfinance.com/",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "FluxDeFi",
-            "facebook_username": null,
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "+feNWURgESeoyMmRh",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/29052/thumb/fDAI_200x200.png?1676335235",
-            "small": "https://assets.coingecko.com/coins/images/29052/small/fDAI_200x200.png?1676335235",
-            "large": "https://assets.coingecko.com/coins/images/29052/large/fDAI_200x200.png?1676335235"
-        },
-        "country_origin": null,
-        "genesis_date": null,
-        "contract_address": "0xe2ba8693ce7474900a045757fe0efca900f6530b",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 4,
-        "market_cap_rank": null,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {},
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {},
-            "ath_change_percentage": {
-                "usd": 0
-            },
-            "ath_date": {},
-            "atl": {},
-            "atl_change_percentage": {
-                "usd": 0
-            },
-            "atl_date": {},
-            "market_cap": {},
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {},
-            "total_volume": {},
-            "high_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "low_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "price_change_24h": null,
-            "price_change_percentage_24h": null,
-            "price_change_percentage_7d": 0,
-            "price_change_percentage_14d": 0,
-            "price_change_percentage_30d": 0,
-            "price_change_percentage_60d": 0,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": null,
-            "market_cap_change_percentage_24h": null,
-            "price_change_24h_in_currency": {},
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {},
-            "price_change_percentage_7d_in_currency": {},
-            "price_change_percentage_14d_in_currency": {},
-            "price_change_percentage_30d_in_currency": {},
-            "price_change_percentage_60d_in_currency": {},
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {},
-            "market_cap_change_percentage_24h_in_currency": {},
-            "total_supply": null,
-            "max_supply": null,
-            "circulating_supply": null,
-            "last_updated": null
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": null
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab"
+      }
     },
-    {
-        "id": "flux-frax",
-        "symbol": "ffrax",
-        "name": "Flux FRAX",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 8,
-                "contract_address": "0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [],
-        "public_notice": null,
-        "additional_notices": [
-            "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
-        ],
-        "description": {
-            "en": "Each asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fFRAX, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets."
-        },
-        "links": {
-            "homepage": [
-                "https://fluxfinance.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x1C9A2d6b33B4826757273D47ebEe0e2DddcD978B",
-                "https://ethplorer.io/address/0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.fluxfinance.com/",
-                "https://blog.fluxfinance.com/",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "FluxDeFi",
-            "facebook_username": null,
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": null,
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/29580/thumb/fFRAX-320.png?1679813767",
-            "small": "https://assets.coingecko.com/coins/images/29580/small/fFRAX-320.png?1679813767",
-            "large": "https://assets.coingecko.com/coins/images/29580/large/fFRAX-320.png?1679813767"
-        },
-        "country_origin": null,
-        "genesis_date": null,
-        "contract_address": "0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 4,
-        "market_cap_rank": null,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {},
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {},
-            "ath_change_percentage": {
-                "usd": 0
-            },
-            "ath_date": {},
-            "atl": {},
-            "atl_change_percentage": {
-                "usd": 0
-            },
-            "atl_date": {},
-            "market_cap": {},
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {},
-            "total_volume": {},
-            "high_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "low_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "price_change_24h": null,
-            "price_change_percentage_24h": null,
-            "price_change_percentage_7d": 0,
-            "price_change_percentage_14d": 0,
-            "price_change_percentage_30d": 0,
-            "price_change_percentage_60d": 0,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": null,
-            "market_cap_change_percentage_24h": null,
-            "price_change_24h_in_currency": {},
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {},
-            "price_change_percentage_7d_in_currency": {},
-            "price_change_percentage_14d_in_currency": {},
-            "price_change_percentage_30d_in_currency": {},
-            "price_change_percentage_60d_in_currency": {},
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {},
-            "market_cap_change_percentage_24h_in_currency": {},
-            "total_supply": null,
-            "max_supply": null,
-            "circulating_supply": null,
-            "last_updated": null
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": null
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "MEV Protection"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "⚗️'s one and only purpose is to find the philosopher's stone and use it to explore the galaxy."
     },
-    {
-        "id": "flux-usdc",
-        "symbol": "fusdc",
-        "name": "Flux USDC",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x465a5a630482f3abd6d3b84b39b29b07214d19e5"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 8,
-                "contract_address": "0x465a5a630482f3abd6d3b84b39b29b07214d19e5"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [],
-        "public_notice": null,
-        "additional_notices": [
-            "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
-        ],
-        "description": {
-            "en": "What is fUSDC?\r\nEach asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fUSDC, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets. \r\n\r\nWhat Makes fUSDC Unique?\r\nfUSDC is minted when users deposit USDC on Flux Finance. By doing so, the user's USDC will become available to borrowers, and the user will earn the USDC supply rate. fUSDC increases in value relative to the underlying USDC, meaning users can redeem more assets over time as interest is earned. The interest rate earned by lenders fluctuates and depends on the market's utilization (i.e. the percentage of deposited assets that have been borrowed).\r\n\r\nHistory of fUSDC\r\nIn January 2023, Flux was announced as a decentralized lending protocol that can support permissionless cryptoassets alongside permissioned tokens. The protocol was initially developed by Ondo Finance, a software development firm in DeFi, before being sold to Flux Finance.\r\n\r\nFlux is governed by the Ondo DAO, in which ONDO holders vote to upgrade its code and alter its risk parameters. In February 2023, the protocol was initialized and its supported assets and parameters were selected in a genesis vote. fUSDC was among the first assets to be selected, alongside fDAI and fOUSG. Markets for these assets opened shortly after.\r\n\r\nWhat can fUSDC be Used For?\r\nBy minting fUSDC, users earn interest and gain the ability to use fUSDC as collateral. fUSDC can be transferred to effect change in ownership. Transferring fUSDC means transferring your balance of the underlying USDC inside the Flux Finance protocol. Transfers that would result in negative account liquidity for borrowers on Flux Finance will fail.\r\n\r\nWhat’s Next for fUSDC?\r\nAs a permissionless yielding asset, fUSDC can in turn be used as collateral at other lending protocols, and offers an alternative settlement option between parties.\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://fluxfinance.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x465a5a630482f3abD6d3b84B39B29b07214d19e5",
-                "https://ethplorer.io/address/0x465a5a630482f3abD6d3b84B39B29b07214d19e5",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/YzhZaFbB92",
-                "https://blog.fluxfinance.com/",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "FluxDeFi",
-            "facebook_username": null,
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "+feNWURgESeoyMmRh",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/29051/thumb/fUSDC_200x200.png?1676335208",
-            "small": "https://assets.coingecko.com/coins/images/29051/small/fUSDC_200x200.png?1676335208",
-            "large": "https://assets.coingecko.com/coins/images/29051/large/fUSDC_200x200.png?1676335208"
-        },
-        "country_origin": null,
-        "genesis_date": null,
-        "contract_address": "0x465a5a630482f3abd6d3b84b39b29b07214d19e5",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 2,
-        "market_cap_rank": null,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {},
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {},
-            "ath_change_percentage": {
-                "usd": 0
-            },
-            "ath_date": {},
-            "atl": {},
-            "atl_change_percentage": {
-                "usd": 0
-            },
-            "atl_date": {},
-            "market_cap": {},
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {},
-            "total_volume": {},
-            "high_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "low_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "price_change_24h": null,
-            "price_change_percentage_24h": null,
-            "price_change_percentage_7d": 0,
-            "price_change_percentage_14d": 0,
-            "price_change_percentage_30d": 0,
-            "price_change_percentage_60d": 0,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": null,
-            "market_cap_change_percentage_24h": null,
-            "price_change_24h_in_currency": {},
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {},
-            "price_change_percentage_7d_in_currency": {},
-            "price_change_percentage_14d_in_currency": {},
-            "price_change_percentage_30d_in_currency": {},
-            "price_change_percentage_60d_in_currency": {},
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {},
-            "market_cap_change_percentage_24h_in_currency": {},
-            "total_supply": null,
-            "max_supply": null,
-            "circulating_supply": null,
-            "last_updated": null
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": null
+    "links": {
+      "homepage": ["https://www.alchemist.wtf/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+        "https://ethplorer.io/address/0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/alchemist", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "_alchemistcoin",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/alchemistcoin/alchemist"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "flux-usdt",
-        "symbol": "fusdt",
-        "name": "Flux USDT",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 8,
-                "contract_address": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [],
-        "public_notice": null,
-        "additional_notices": [
-            "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
-        ],
-        "description": {
-            "en": "Each asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fUSDT, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets. "
-        },
-        "links": {
-            "homepage": [
-                "https://fluxfinance.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x81994b9607e06ab3d5cF3AffF9a67374f05F27d7",
-                "https://ethplorer.io/address/0x81994b9607e06ab3d5cf3afff9a67374f05f27d7",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://www.discord.fluxfinance.com",
-                "https://blog.fluxfinance.com/",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "FluxDeFi",
-            "facebook_username": null,
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": null,
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/29581/thumb/fUSDT-320.png?1679813769",
-            "small": "https://assets.coingecko.com/coins/images/29581/small/fUSDT-320.png?1679813769",
-            "large": "https://assets.coingecko.com/coins/images/29581/large/fUSDT-320.png?1679813769"
-        },
-        "country_origin": null,
-        "genesis_date": null,
-        "contract_address": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 18,
-        "market_cap_rank": null,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {},
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {},
-            "ath_change_percentage": {
-                "usd": 0
-            },
-            "ath_date": {},
-            "atl": {},
-            "atl_change_percentage": {
-                "usd": 0
-            },
-            "atl_date": {},
-            "market_cap": {},
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {},
-            "total_volume": {},
-            "high_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "low_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "price_change_24h": null,
-            "price_change_percentage_24h": null,
-            "price_change_percentage_7d": 0,
-            "price_change_percentage_14d": 0,
-            "price_change_percentage_30d": 0,
-            "price_change_percentage_60d": 0,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": null,
-            "market_cap_change_percentage_24h": null,
-            "price_change_24h_in_currency": {},
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {},
-            "price_change_percentage_7d_in_currency": {},
-            "price_change_percentage_14d_in_currency": {},
-            "price_change_percentage_30d_in_currency": {},
-            "price_change_percentage_60d_in_currency": {},
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {},
-            "market_cap_change_percentage_24h_in_currency": {},
-            "total_supply": null,
-            "max_supply": null,
-            "circulating_supply": null,
-            "last_updated": null
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": null
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14655/thumb/79158662.png?1617589045",
+      "small": "https://assets.coingecko.com/coins/images/14655/small/79158662.png?1617589045",
+      "large": "https://assets.coingecko.com/coins/images/14655/large/79158662.png?1617589045"
     },
-   
-    {
-        "id": "frax",
-        "symbol": "frax",
-        "name": "Frax",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x853d955acef822db058eb8505911ed77f175b99e",
-            "optimistic-ethereum": "0x2e3d870790dc77a83dd1d18184acc7439a53f475",
-            "near-protocol": "853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near",
-            "polygon-zkevm": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d",
-            "moonbeam": "0x322e86852e492a7ee17f28a78c663da38fb33bfb",
-            "binance-smart-chain": "0x90c97f71e18723b0cf0dfa30ee176ab653e89f40",
-            "avalanche": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
-            "polygon-pos": "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89",
-            "fantom": "0xdc301622e621166bd8e82f2ca0a26c13ad0be355",
-            "harmony-shard-0": "0xfa7191d292d5633f702b0bd7e3e3bccc0e633200",
-            "arbitrum-one": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
-            "moonriver": "0x1a93b23281cc1cde4c4741353f3064709a16197d",
-            "solana": "FR87nWEUxVgerFGhZM8Y4AggKGLnaXswr1Pd8wZ4kZcp",
-            "evmos": "0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x853d955acef822db058eb8505911ed77f175b99e"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x2e3d870790dc77a83dd1d18184acc7439a53f475"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near"
-            },
-            "polygon-zkevm": {
-                "decimal_place": 18,
-                "contract_address": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d"
-            },
-            "moonbeam": {
-                "decimal_place": 18,
-                "contract_address": "0x322e86852e492a7ee17f28a78c663da38fb33bfb"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0x90c97f71e18723b0cf0dfa30ee176ab653e89f40"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0xdc301622e621166bd8e82f2ca0a26c13ad0be355"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0xfa7191d292d5633f702b0bd7e3e3bccc0e633200"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f"
-            },
-            "moonriver": {
-                "decimal_place": 18,
-                "contract_address": "0x1a93b23281cc1cde4c4741353f3064709a16197d"
-            },
-            "solana": {
-                "decimal_place": 18,
-                "contract_address": "FR87nWEUxVgerFGhZM8Y4AggKGLnaXswr1Pd8wZ4kZcp"
-            },
-            "evmos": {
-                "decimal_place": 18,
-                "contract_address": "0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Solana Ecosystem",
-            "Moonbeam Ecosystem",
-            "Optimism Ecosystem",
-            "Harmony Ecosystem",
-            "Arbitrum Ecosystem",
-            "Fantom Ecosystem",
-            "Ethereum Ecosystem",
-            "BNB Chain Ecosystem",
-            "Moonriver Ecosystem",
-            "USD Stablecoin",
-            "Polygon Ecosystem",
-            "Avalanche Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Stablecoins",
-            "Seigniorage"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "The first fractional-algorithmic stablecoin"
-        },
-        "links": {
-            "homepage": [
-                "https://frax.finance",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x853d955acef822db058eb8505911ed77f175b99e",
-                "https://ethplorer.io/address/0x853d955acef822db058eb8505911ed77f175b99e",
-                "https://polygonscan.com/token/0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89",
-                "https://bscscan.com/token/0x90C97F71E18723b0Cf0dfa30ee176Ab653E89F40",
-                "https://avascan.info/blockchain/c/address/0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64",
-                "https://snowtrace.io/token/0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
-                "https://moonriver.moonscan.io/token/0x1a93b23281cc1cde4c4741353f3064709a16197d",
-                "https://arbiscan.io/token/0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
-                "https://nearblocks.io/token/853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near",
-                "https://scan.meter.io/address/0xdc301622e621166bd8e82f2ca0a26c13ad0be355"
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/MTZu6Hf57d",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "fraxfinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "fraxfinance",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/fraxfinance/frax-solidity"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/13422/thumb/FRAX_icon.png?1679886922",
-            "small": "https://assets.coingecko.com/coins/images/13422/small/FRAX_icon.png?1679886922",
-            "large": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1679886922"
-        },
-        "country_origin": "KY",
-        "genesis_date": null,
-        "contract_address": "0x853d955acef822db058eb8505911ed77f175b99e",
-        "sentiment_votes_up_percentage": 0,
-        "sentiment_votes_down_percentage": 100,
-        "watchlist_portfolio_users": 8682,
-        "market_cap_rank": 41,
-        "coingecko_rank": 567,
-        "coingecko_score": 26.382,
-        "developer_score": 0,
-        "community_score": 9.224,
-        "liquidity_score": 42.81,
-        "public_interest_score": 0.005,
-        "market_data": {
-            "current_price": {
-                "usd": 1.001
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1.14
-            },
-            "ath_change_percentage": {
-                "usd": -12.44844
-            },
-            "ath_date": {
-                "usd": "2021-02-07T12:55:35.766Z"
-            },
-            "atl": {
-                "usd": 0.874536
-            },
-            "atl_change_percentage": {
-                "usd": 14.17283
-            },
-            "atl_date": {
-                "usd": "2023-03-11T07:50:39.316Z"
-            },
-            "market_cap": {
-                "usd": 1002705251
-            },
-            "market_cap_rank": 41,
-            "fully_diluted_valuation": {
-                "usd": 1002705251
-            },
-            "total_volume": {
-                "usd": 10780852
-            },
-            "high_24h": {
-                "usd": 1.004
-            },
-            "low_24h": {
-                "usd": 0.994519
-            },
-            "price_change_24h": 0.00089328,
-            "price_change_percentage_24h": 0.08933,
-            "price_change_percentage_7d": 0.05894,
-            "price_change_percentage_14d": 0.17096,
-            "price_change_percentage_30d": 0.04585,
-            "price_change_percentage_60d": 0.21901,
-            "price_change_percentage_200d": 0.31426,
-            "price_change_percentage_1y": -0.53772,
-            "market_cap_change_24h": -913390.87192,
-            "market_cap_change_percentage_24h": -0.09101,
-            "price_change_24h_in_currency": {
-                "usd": 0.00089328
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.27342
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.08933
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 0.05894
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 0.17096
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 0.04585
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": 0.21901
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 0.31426
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -0.53772
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -913390.8719199896
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.09101
-            },
-            "total_supply": 1004141409.40878,
-            "max_supply": 1004141409.40878,
-            "circulating_supply": 1004141409.40878,
-            "last_updated": "2023-06-27T11:46:02.963Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:46:02.963Z"
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 13031,
+    "market_cap_rank": 1529,
+    "coingecko_rank": 613,
+    "coingecko_score": 25.698,
+    "developer_score": 37.179,
+    "community_score": 8.659,
+    "liquidity_score": 16.354,
+    "public_interest_score": 0.001,
+    "market_data": {
+      "current_price": {
+        "usd": 1.37
+      },
+      "total_value_locked": {
+        "usd": 1019611
+      },
+      "mcap_to_tvl_ratio": 2.46,
+      "fdv_to_tvl_ratio": 2.46,
+      "roi": null,
+      "ath": {
+        "usd": 225.39
+      },
+      "ath_change_percentage": {
+        "usd": -99.39295
+      },
+      "ath_date": {
+        "usd": "2021-04-26T12:03:04.025Z"
+      },
+      "atl": {
+        "usd": 0.550984
+      },
+      "atl_change_percentage": {
+        "usd": 148.32188
+      },
+      "atl_date": {
+        "usd": "2023-06-21T12:28:46.822Z"
+      },
+      "market_cap": {
+        "usd": 2510355
+      },
+      "market_cap_rank": 1529,
+      "fully_diluted_valuation": {
+        "usd": 2510355
+      },
+      "total_volume": {
+        "usd": 2913.53
+      },
+      "high_24h": {
+        "usd": 1.38
+      },
+      "low_24h": {
+        "usd": 1.34
+      },
+      "price_change_24h": 0.02709355,
+      "price_change_percentage_24h": 2.02022,
+      "price_change_percentage_7d": 4.97742,
+      "price_change_percentage_14d": 10.01591,
+      "price_change_percentage_30d": -3.60085,
+      "price_change_percentage_60d": -9.79472,
+      "price_change_percentage_200d": -15.02771,
+      "price_change_percentage_1y": -52.55821,
+      "market_cap_change_24h": 49681,
+      "market_cap_change_percentage_24h": 2.01901,
+      "price_change_24h_in_currency": {
+        "usd": 0.02709355
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.2541
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.02022
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 4.97742
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 10.01591
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -3.60085
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -9.79472
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -15.02771
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -52.55821
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 49681
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.01901
+      },
+      "total_supply": 1834863.66554973,
+      "max_supply": null,
+      "circulating_supply": 1834863.66554973,
+      "last_updated": "2023-07-03T17:40:51.740Z"
     },
-    {
-        "id": "frax-share",
-        "symbol": "fxs",
-        "name": "Frax Share",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-            "polygon-zkevm": "0x6b856a14cea1d7dcfaf80fa6936c0b75972ccace",
-            "solana": "6LX8BhMQ4Sy2otmAWj7Y5sKd9YTVVUgfMsBzT6B9W7ct",
-            "binance-smart-chain": "0xe48a3d7d0bc88d552f730b62c006bc925eadb9ee",
-            "polygon-pos": "0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
-            "avalanche": "0x214db107654ff987ad859f34125307783fc8e387",
-            "fantom": "0x7d016eec9c25232b01f23ef992d98ca97fc2af5a",
-            "arbitrum-one": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
-            "harmony-shard-0": "0x0767d8e1b05efa8d6a301a65b324b6b66a1cc14c",
-            "moonriver": "0x6f1d1ee50846fcbc3de91723e61cb68cfa6d0e98",
-            "evmos": "0xd8176865dd0d672c6ab4a427572f80a72b4b4a9c"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0"
-            },
-            "polygon-zkevm": {
-                "decimal_place": 18,
-                "contract_address": "0x6b856a14cea1d7dcfaf80fa6936c0b75972ccace"
-            },
-            "solana": {
-                "decimal_place": 18,
-                "contract_address": "6LX8BhMQ4Sy2otmAWj7Y5sKd9YTVVUgfMsBzT6B9W7ct"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xe48a3d7d0bc88d552f730b62c006bc925eadb9ee"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x1a3acf6d19267e2d3e7f898f42803e90c9219062"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0x214db107654ff987ad859f34125307783fc8e387"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x7d016eec9c25232b01f23ef992d98ca97fc2af5a"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0x0767d8e1b05efa8d6a301a65b324b6b66a1cc14c"
-            },
-            "moonriver": {
-                "decimal_place": 18,
-                "contract_address": "0x6f1d1ee50846fcbc3de91723e61cb68cfa6d0e98"
-            },
-            "evmos": {
-                "decimal_place": 18,
-                "contract_address": "0xd8176865dd0d672c6ab4a427572f80a72b4b4a9c"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Solana Ecosystem",
-            "Liquid Staking Governance Tokens",
-            "Harmony Ecosystem",
-            "Ethereum Ecosystem",
-            "Moonriver Ecosystem",
-            "Arbitrum Ecosystem",
-            "Fantom Ecosystem",
-            "Polygon Ecosystem",
-            "BNB Chain Ecosystem",
-            "Olympus Pro",
-            "Avalanche Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Seigniorage"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "The Frax Share token is the governance and value accrual token of the Frax Stablecoin Protocol"
-        },
-        "links": {
-            "homepage": [
-                "https://frax.finance",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-                "https://ethplorer.io/address/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-                "https://bscscan.com/token/0xe48A3d7d0Bc88d552f730B62c006bC925eadB9eE",
-                "https://ftmscan.com/token/0x7d016eec9c25232b01f23ef992d98ca97fc2af5a",
-                "https://arbiscan.io/token/0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
-                "https://polygonscan.com/token/0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
-                "https://snowtrace.io/token/0x214db107654ff987ad859f34125307783fc8e387",
-                "https://moonriver.moonscan.io/token/0x6f1d1ee50846fcbc3de91723e61cb68cfa6d0e98",
-                "https://scan.meter.io/address/0x7d016eec9c25232b01f23ef992d98ca97fc2af5a",
-                "https://ftmscan.com/address/0x7d016eec9c25232b01f23ef992d98ca97fc2af5a"
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/MTZu6Hf57d",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "fraxfinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "fraxfinance",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/fraxfinance/frax-solidity"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/13423/thumb/Frax_Shares_icon.png?1679886947",
-            "small": "https://assets.coingecko.com/coins/images/13423/small/Frax_Shares_icon.png?1679886947",
-            "large": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1679886947"
-        },
-        "country_origin": "KY",
-        "genesis_date": null,
-        "contract_address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-        "sentiment_votes_up_percentage": 50,
-        "sentiment_votes_down_percentage": 50,
-        "watchlist_portfolio_users": 29669,
-        "market_cap_rank": 96,
-        "coingecko_rank": 666,
-        "coingecko_score": 25.054,
-        "developer_score": 0,
-        "community_score": 9.224,
-        "liquidity_score": 41.82,
-        "public_interest_score": 0.005,
-        "market_data": {
-            "current_price": {
-                "usd": 5.82
-            },
-            "total_value_locked": {
-                "usd": 188325913
-            },
-            "mcap_to_tvl_ratio": 2.24,
-            "fdv_to_tvl_ratio": 3.07,
-            "roi": null,
-            "ath": {
-                "usd": 42.8
-            },
-            "ath_change_percentage": {
-                "usd": -86.44568
-            },
-            "ath_date": {
-                "usd": "2022-01-12T15:22:27.465Z"
-            },
-            "atl": {
-                "usd": 1.5
-            },
-            "atl_change_percentage": {
-                "usd": 285.93494
-            },
-            "atl_date": {
-                "usd": "2021-06-25T16:50:51.447Z"
-            },
-            "market_cap": {
-                "usd": 421734444
-            },
-            "market_cap_rank": 96,
-            "fully_diluted_valuation": {
-                "usd": 578371033
-            },
-            "total_volume": {
-                "usd": 18438705
-            },
-            "high_24h": {
-                "usd": 6.14
-            },
-            "low_24h": {
-                "usd": 5.8
-            },
-            "price_change_24h": -0.05294709140073,
-            "price_change_percentage_24h": -0.90212,
-            "price_change_percentage_7d": 3.66039,
-            "price_change_percentage_14d": 14.39015,
-            "price_change_percentage_30d": -16.99107,
-            "price_change_percentage_60d": -29.41055,
-            "price_change_percentage_200d": -4.46086,
-            "price_change_percentage_1y": -0.24215,
-            "market_cap_change_24h": -4870471.088845,
-            "market_cap_change_percentage_24h": -1.14168,
-            "price_change_24h_in_currency": {
-                "usd": -0.0529470914007284
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.20095
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.90212
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 3.66039
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 14.39015
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -16.99107
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -29.41055
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -4.46086
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -0.24215
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -4870471.088844895
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.14168
-            },
-            "total_supply": 99707752.7128909,
-            "max_supply": 99707752.7128909,
-            "circulating_supply": 72704529.1725658,
-            "last_updated": "2023-06-27T11:46:02.720Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:46:02.720Z"
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
     },
-    {
-        "id": "gitcoin",
-        "symbol": "gtc",
-        "name": "Gitcoin",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
-            "near-protocol": "de30da39c46104798bb5aa3fe8b9e0e1f348163f.factory.bridge.near"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
-            },
-            "near-protocol": {
-                "decimal_place": 18,
-                "contract_address": "de30da39c46104798bb5aa3fe8b9e0e1f348163f.factory.bridge.near"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Gitcoin is a platform to fund builders looking for meaningful, open source work."
-        },
-        "links": {
-            "homepage": [
-                "https://gitcoin.co/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
-                "https://ethplorer.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
-                "https://nearblocks.io/token/de30da39c46104798bb5aa3fe8b9e0e1f348163f.factory.bridge.near",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/gitcoin",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "gitcoin",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": "https://www.reddit.com/r/gitcoincommunity",
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
-            "small": "https://assets.coingecko.com/coins/images/15810/small/gitcoin.png?1621992929",
-            "large": "https://assets.coingecko.com/coins/images/15810/large/gitcoin.png?1621992929"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 14392,
-        "market_cap_rank": 335,
-        "coingecko_rank": 506,
-        "coingecko_score": 27.47,
-        "developer_score": 0,
-        "community_score": 32.649,
-        "liquidity_score": 37.251,
-        "public_interest_score": 0.04,
-        "market_data": {
-            "current_price": {
-                "usd": 1.14
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 89.62
-            },
-            "ath_change_percentage": {
-                "usd": -98.73191
-            },
-            "ath_date": {
-                "usd": "2021-05-25T15:33:23.602Z"
-            },
-            "atl": {
-                "usd": 0.841165
-            },
-            "atl_change_percentage": {
-                "usd": 35.11232
-            },
-            "atl_date": {
-                "usd": "2023-06-10T04:31:37.518Z"
-            },
-            "market_cap": {
-                "usd": 69354212
-            },
-            "market_cap_rank": 335,
-            "fully_diluted_valuation": {
-                "usd": 113950657
-            },
-            "total_volume": {
-                "usd": 2760694
-            },
-            "high_24h": {
-                "usd": 1.17
-            },
-            "low_24h": {
-                "usd": 1.12
-            },
-            "price_change_24h": -0.007385594147820001,
-            "price_change_percentage_24h": -0.64488,
-            "price_change_percentage_7d": 19.29861,
-            "price_change_percentage_14d": 18.8833,
-            "price_change_percentage_30d": -21.95332,
-            "price_change_percentage_60d": -30.51631,
-            "price_change_percentage_200d": -36.91116,
-            "price_change_percentage_1y": -62.08903,
-            "market_cap_change_24h": -685920.1001427,
-            "market_cap_change_percentage_24h": -0.97932,
-            "price_change_24h_in_currency": {
-                "usd": -0.007385594147822695
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.23155
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.64488
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 19.29861
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 18.8833
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -21.95332
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -30.51631
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -36.91116
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -62.08903
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -685920.1001426727
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.97932
-            },
-            "total_supply": 100000000,
-            "max_supply": 100000000,
-            "circulating_supply": 60863371.560695864,
-            "last_updated": "2023-06-27T11:46:17.440Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:46:17.440Z"
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:40:51.740Z"
+  },
+  {
+    "id": "alchemix",
+    "symbol": "alcx",
+    "name": "Alchemix",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+      "near-protocol": "dbdb4d16eda451d0503b854cf79d55697f90c8df.factory.bridge.near"
     },
-    {
-        "id": "gitcoin-staked-eth-index",
-        "symbol": "gtceth",
-        "name": "Gitcoin Staked ETH Index",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x36c833eed0d376f75d1ff9dfdee260191336065e"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x36c833eed0d376f75d1ff9dfdee260191336065e"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "The Gitcoin Staked ETH Index (gtcETH) is an index token made up of the leading Ethereum liquid staking tokens. In addition to a methodology that encourages decentralization, gtcETH shares a portion of staking rewards with Gitcoin in support of public goods funding."
-        },
-        "links": {
-            "homepage": [
-                "https://indexcoop.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/address/0x36c833eed0d376f75d1ff9dfdee260191336065e",
-                "https://etherscan.io/token/0x36c833eed0d376f75d1ff9dfdee260191336065e",
-                "https://ethplorer.io/address/0x36c833eed0d376f75d1ff9dfdee260191336065e",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://www.linkedin.com/company/index-coop/",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/indexcoop",
-                "https://indexcoop.com/blog",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/IndexCoop/index-protocol"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/29171/thumb/gtcETH-token-logo.png?1677060167",
-            "small": "https://assets.coingecko.com/coins/images/29171/small/gtcETH-token-logo.png?1677060167",
-            "large": "https://assets.coingecko.com/coins/images/29171/large/gtcETH-token-logo.png?1677060167"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x36c833eed0d376f75d1ff9dfdee260191336065e",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 25,
-        "market_cap_rank": 2903,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 1918.04
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1960.01
-            },
-            "ath_change_percentage": {
-                "usd": -2.14131
-            },
-            "ath_date": {
-                "usd": "2023-06-22T03:06:57.743Z"
-            },
-            "atl": {
-                "usd": 1394.93
-            },
-            "atl_change_percentage": {
-                "usd": 37.5006
-            },
-            "atl_date": {
-                "usd": "2023-03-10T11:49:41.620Z"
-            },
-            "market_cap": {
-                "usd": 141647
-            },
-            "market_cap_rank": 2903,
-            "fully_diluted_valuation": {
-                "usd": 141647
-            },
-            "total_volume": {
-                "usd": 207.48
-            },
-            "high_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "low_24h": {
-                "AED": null,
-                "ARS": null,
-                "AUD": null,
-                "BCH": null,
-                "BDT": null,
-                "BHD": null,
-                "BMD": null,
-                "BNB": null,
-                "BRL": null,
-                "BTC": null,
-                "CAD": null,
-                "CHF": null,
-                "CLP": null,
-                "CNY": null,
-                "CZK": null,
-                "DKK": null,
-                "DOT": null,
-                "EOS": null,
-                "ETH": null,
-                "EUR": null,
-                "GBP": null,
-                "HKD": null,
-                "HUF": null,
-                "IDR": null,
-                "ILS": null,
-                "INR": null,
-                "JPY": null,
-                "KRW": null,
-                "KWD": null,
-                "LKR": null,
-                "LTC": null,
-                "MMK": null,
-                "MXN": null,
-                "MYR": null,
-                "NGN": null,
-                "NOK": null,
-                "NZD": null,
-                "PHP": null,
-                "PKR": null,
-                "PLN": null,
-                "RUB": null,
-                "SAR": null,
-                "SEK": null,
-                "SGD": null,
-                "THB": null,
-                "TRY": null,
-                "TWD": null,
-                "UAH": null,
-                "USD": null,
-                "VEF": null,
-                "VND": null,
-                "XAG": null,
-                "XAU": null,
-                "XDR": null,
-                "XLM": null,
-                "XRP": null,
-                "YFI": null,
-                "ZAR": null,
-                "BITS": null,
-                "LINK": null,
-                "SATS": null
-            },
-            "price_change_24h": null,
-            "price_change_percentage_24h": null,
-            "price_change_percentage_7d": 10.60223,
-            "price_change_percentage_14d": 8.28313,
-            "price_change_percentage_30d": 4.15358,
-            "price_change_percentage_60d": 5.10969,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": null,
-            "market_cap_change_percentage_24h": null,
-            "price_change_24h_in_currency": {},
-            "price_change_percentage_1h_in_currency": {},
-            "price_change_percentage_24h_in_currency": {},
-            "price_change_percentage_7d_in_currency": {
-                "usd": 10.60223
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 8.28313
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 4.15358
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": 5.10969
-            },
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {},
-            "market_cap_change_percentage_24h_in_currency": {},
-            "total_supply": 73.85,
-            "max_supply": null,
-            "circulating_supply": 73.85,
-            "last_updated": "2023-06-22T17:54:02.035Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-22T17:54:02.035Z"
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "dbdb4d16eda451d0503b854cf79d55697f90c8df.factory.bridge.near"
+      }
     },
-    {
-        "id": "giveth",
-        "symbol": "giv",
-        "name": "Giveth",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x900db999074d9277c5da2a43f252d74366230da0",
-            "xdai": "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x900db999074d9277c5da2a43f252d74366230da0"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Gnosis Chain Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Giveth is a community focused on Building the Future of Giving using blockchain technology. Our intention is to support and reward the funding of public goods by creating open, transparent and free access to the revolutionary funding opportunities available within the Ethereum ecosystem. Check out our Calendar and Join Page to get more involved."
-        },
-        "links": {
-            "homepage": [
-                "https://giveth.io/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x900db999074d9277c5da2a43f252d74366230da0",
-                "https://ethplorer.io/address/0x900db999074d9277c5da2a43f252d74366230da0",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/Uq2TaXP9bC",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/giveth",
-                ""
-            ],
-            "twitter_screen_name": "Givethio",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "Givethio",
-            "subreddit_url": "https://www.reddit.com/r/giveth/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/Giveth/giv-token-contracts"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/21792/thumb/GIVToken_200x200.png?1640055088",
-            "small": "https://assets.coingecko.com/coins/images/21792/small/GIVToken_200x200.png?1640055088",
-            "large": "https://assets.coingecko.com/coins/images/21792/large/GIVToken_200x200.png?1640055088"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x900db999074d9277c5da2a43f252d74366230da0",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 342,
-        "market_cap_rank": 1808,
-        "coingecko_rank": 465,
-        "coingecko_score": 28.383,
-        "developer_score": 48.304,
-        "community_score": 23.557,
-        "liquidity_score": 1,
-        "public_interest_score": 0.004,
-        "market_data": {
-            "current_price": {
-                "usd": 0.01024519
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1.017
-            },
-            "ath_change_percentage": {
-                "usd": -98.99233
-            },
-            "ath_date": {
-                "usd": "2021-12-28T07:33:54.071Z"
-            },
-            "atl": {
-                "usd": 0.00367537
-            },
-            "atl_change_percentage": {
-                "usd": 178.75283
-            },
-            "atl_date": {
-                "usd": "2022-12-17T10:22:58.350Z"
-            },
-            "market_cap": {
-                "usd": 1431011
-            },
-            "market_cap_rank": 1808,
-            "fully_diluted_valuation": {
-                "usd": 10235579
-            },
-            "total_volume": {
-                "usd": 254.91
-            },
-            "high_24h": {
-                "usd": 0.01062771
-            },
-            "low_24h": {
-                "usd": 0.00990394
-            },
-            "price_change_24h": 0.00010003,
-            "price_change_percentage_24h": 0.98601,
-            "price_change_percentage_7d": 9.28016,
-            "price_change_percentage_14d": 2.71238,
-            "price_change_percentage_30d": -8.16901,
-            "price_change_percentage_60d": -20.53819,
-            "price_change_percentage_200d": -50.18841,
-            "price_change_percentage_1y": -82.78763,
-            "market_cap_change_24h": 60773,
-            "market_cap_change_percentage_24h": 4.43524,
-            "price_change_24h_in_currency": {
-                "usd": 0.00010003
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.01255
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.98601
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 9.28016
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 2.71238
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -8.16901
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -20.53819
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -50.18841
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -82.78763
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 60773
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 4.43524
-            },
-            "total_supply": 1000000000,
-            "max_supply": 1000000000,
-            "circulating_supply": 139807564.517741,
-            "last_updated": "2023-06-27T11:42:11.774Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:42:11.774Z"
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Ethereum Ecosystem",
+      "Olympus Pro",
+      "Lending/Borrowing",
+      "Yield Farming",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Alchemix token is the governance token for the Alchemix protocol. "
     },
-    {
-        "id": "hex",
-        "symbol": "hex",
-        "name": "HEX",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
-            "polygon-pos": "0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c",
-            "harmony-shard-0": "0xf26d8c787e66254ee8b7a500073da8fb1ab1992d"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 8,
-                "contract_address": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39"
-            },
-            "polygon-pos": {
-                "decimal_place": 8,
-                "contract_address": "0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 8,
-                "contract_address": "0xf26d8c787e66254ee8b7a500073da8fb1ab1992d"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": "Ethash",
-        "categories": [
-            "PulseChain Ecosystem",
-            "Harmony Ecosystem",
-            "Polygon Ecosystem",
-            "Ethereum Ecosystem",
-            "Cryptocurrency"
-        ],
-        "public_notice": "NOTE: Due to the price difference on PulseChain, HEX (PulseChain) is tracked separately to avoid confusion. Kindly visit the token page <a href=https://www.coingecko.com/en/coins/hex-pulsechain>here</a>.",
-        "additional_notices": [],
-        "description": {
-            "en": "Launched on December 2, 2019 by Richard Heart and team, HEX is the first certificate of deposit on the blockchain, essentially time deposits that gain interest, HEX is an ERC20 Token that runs over the Ethereum network\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://hex.com",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
-                "https://ethplorer.io/address/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
-                "https://polygonscan.com/token/0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c",
-                "https://scan.pulsechain.com/token/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discordapp.com/invite/CA8jVuF",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "HEXcrypto",
-            "facebook_username": "HEXcrypto",
-            "bitcointalk_thread_identifier": 4523610,
-            "telegram_channel_identifier": "HEXcrypto",
-            "subreddit_url": "https://www.reddit.com/r/HEXcrypto/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/HexCommunity"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/10103/thumb/HEX-logo.png?1575942673",
-            "small": "https://assets.coingecko.com/coins/images/10103/small/HEX-logo.png?1575942673",
-            "large": "https://assets.coingecko.com/coins/images/10103/large/HEX-logo.png?1575942673"
-        },
-        "country_origin": "US",
-        "genesis_date": null,
-        "contract_address": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
-        "sentiment_votes_up_percentage": 53.49,
-        "sentiment_votes_down_percentage": 46.51,
-        "watchlist_portfolio_users": 53239,
-        "market_cap_rank": null,
-        "coingecko_rank": 1558,
-        "coingecko_score": 17.405,
-        "developer_score": 0,
-        "community_score": 40.488,
-        "liquidity_score": 42.481,
-        "public_interest_score": 0.029,
-        "market_data": {
-            "current_price": {
-                "usd": 0.00834899
-            },
-            "total_value_locked": {
-                "usd": 0
-            },
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 0.51083
-            },
-            "ath_change_percentage": {
-                "usd": -98.36767
-            },
-            "ath_date": {
-                "usd": "2021-09-19T06:39:56.189Z"
-            },
-            "atl": {
-                "usd": 0.00005645
-            },
-            "atl_change_percentage": {
-                "usd": 14671.96332
-            },
-            "atl_date": {
-                "usd": "2020-01-05T06:29:30.998Z"
-            },
-            "market_cap": {
-                "usd": 0
-            },
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {
-                "usd": 4908483202
-            },
-            "total_volume": {
-                "usd": 1803644
-            },
-            "high_24h": {
-                "usd": 0.00843198
-            },
-            "low_24h": {
-                "usd": 0.00781222
-            },
-            "price_change_24h": 0.00000136,
-            "price_change_percentage_24h": 0.01629,
-            "price_change_percentage_7d": -1.92782,
-            "price_change_percentage_14d": 6.25548,
-            "price_change_percentage_30d": -33.04926,
-            "price_change_percentage_60d": -84.41575,
-            "price_change_percentage_200d": -70.99329,
-            "price_change_percentage_1y": -81.53697,
-            "market_cap_change_24h": 0,
-            "market_cap_change_percentage_24h": 0,
-            "price_change_24h_in_currency": {
-                "usd": 0.00000136
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.25453
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.01629
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -1.92782
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 6.25548
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -33.04926
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -84.41575
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -70.99329
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -81.53697
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 0
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0
-            },
-            "total_supply": 588678073837.316,
-            "max_supply": null,
-            "circulating_supply": 0,
-            "last_updated": "2023-06-27T11:46:12.037Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 21315,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:46:12.037Z"
+    "links": {
+      "homepage": ["https://alchemix.fi/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+        "https://ethplorer.io/address/0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+        "https://nearblocks.io/token/dbdb4d16eda451d0503b854cf79d55697f90c8df.factory.bridge.near",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/zAd6dzgwaj", "", ""],
+      "announcement_url": ["https://alchemixfi.medium.com/", ""],
+      "twitter_screen_name": "alchemixfi",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/alchemix-finance"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "honey",
-        "symbol": "hny",
-        "name": "Honey",
-        "asset_platform_id": "xdai",
-        "platforms": {
-            "xdai": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
-            "ethereum": "0xc3589f56b6869824804a5ea29f2c9886af1b0fce"
-        },
-        "detail_platforms": {
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9"
-            },
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xc3589f56b6869824804a5ea29f2c9886af1b0fce"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Decentralized Exchange (DEX)"
-        ],
-        "public_notice": null,
-        "additional_notices": [
-            "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
-        ],
-        "description": {
-            "en": "1Hive is a DAO that issues and distributes a digital currency called Honey.\r\nHoney holders stake on proposals using Conviction Voting to determine how issuance is distributed. By supporting proposals which increase the value of Honey, a positive feedback loop drives growth and sustainability.\r\n\r\nConviction Voting allows everyone to participate and shape the direction of 1Hive, while preventing anyone from taking control or ownership."
-        },
-        "links": {
-            "homepage": [
-                "https://1hive.org/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://blockscout.com/poa/xdai/tokens/0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9",
-                "https://etherscan.io/token/0xc3589f56b6869824804a5ea29f2c9886af1b0fce",
-                "https://ethplorer.io/address/0xc3589f56b6869824804a5ea29f2c9886af1b0fce",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/xTZjbRjc8t",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "Honeyswap",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "honeyswapdex",
-            "subreddit_url": "https://www.reddit.com/r/hny",
-            "repos_url": {
-                "github": [
-                    "https://github.com/1Hive"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/12895/thumb/hnys.png?1614100588",
-            "small": "https://assets.coingecko.com/coins/images/12895/small/hnys.png?1614100588",
-            "large": "https://assets.coingecko.com/coins/images/12895/large/hnys.png?1614100588"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 2731,
-        "market_cap_rank": null,
-        "coingecko_rank": 3984,
-        "coingecko_score": 5.748,
-        "developer_score": 0,
-        "community_score": 25.216,
-        "liquidity_score": 1,
-        "public_interest_score": 0.001,
-        "market_data": {
-            "current_price": {
-                "usd": 9.63
-            },
-            "total_value_locked": {
-                "usd": 5640826
-            },
-            "mcap_to_tvl_ratio": 0,
-            "fdv_to_tvl_ratio": 0.06,
-            "roi": null,
-            "ath": {
-                "usd": 2187.59
-            },
-            "ath_change_percentage": {
-                "usd": -99.55964
-            },
-            "ath_date": {
-                "usd": "2021-09-06T05:05:04.933Z"
-            },
-            "atl": {
-                "usd": 0.185133
-            },
-            "atl_change_percentage": {
-                "usd": 5103.38879
-            },
-            "atl_date": {
-                "usd": "2021-09-13T18:45:06.781Z"
-            },
-            "market_cap": {
-                "usd": 0
-            },
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {
-                "usd": 351184
-            },
-            "total_volume": {
-                "usd": 905.3
-            },
-            "high_24h": {
-                "usd": 9.99
-            },
-            "low_24h": {
-                "usd": 9.35
-            },
-            "price_change_24h": 0.081234,
-            "price_change_percentage_24h": 0.85045,
-            "price_change_percentage_7d": 7.18654,
-            "price_change_percentage_14d": 4.0391,
-            "price_change_percentage_30d": -4.50281,
-            "price_change_percentage_60d": -27.20753,
-            "price_change_percentage_200d": -33.6745,
-            "price_change_percentage_1y": -77.46766,
-            "market_cap_change_24h": 0,
-            "market_cap_change_percentage_24h": 0,
-            "price_change_24h_in_currency": {
-                "usd": 0.081234
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.02061
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.85045
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 7.18654
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 4.0391
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -4.50281
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -27.20753
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -33.6745
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -77.46766
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 0
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0
-            },
-            "total_supply": 36489.9752090467,
-            "max_supply": null,
-            "circulating_supply": 0,
-            "last_updated": "2023-06-27T11:42:11.636Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 105341,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:42:11.636Z"
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874",
+      "small": "https://assets.coingecko.com/coins/images/14113/small/Alchemix.png?1614409874",
+      "large": "https://assets.coingecko.com/coins/images/14113/large/Alchemix.png?1614409874"
     },
-    {
-        "id": "hop-protocol",
-        "symbol": "hop",
-        "name": "Hop Protocol",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-            "polygon-pos": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-            "optimistic-ethereum": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-            "arbitrum-one": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-            "xdai": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Polygon Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Arbitrum Ecosystem",
-            "Ethereum Ecosystem",
-            "Optimism Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Hop is a protocol for sending tokens across rollups and their shared layer-1 network in a quick and trustless manner."
-        },
-        "links": {
-            "homepage": [
-                "https://app.hop.exchange/",
-                "https://hop.mirror.xyz/",
-                "https://hop.eth.link/"
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-                "https://ethplorer.io/address/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-                "https://optimistic.etherscan.io/token/0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
-                "https://arbiscan.io/token/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-                "https://polygonscan.com/token/0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/PwCF88emV4",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/hop-protocol",
-                ""
-            ],
-            "twitter_screen_name": "HopProtocol",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/hop-protocol"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1665541677",
-            "small": "https://assets.coingecko.com/coins/images/25445/small/hop.png?1665541677",
-            "large": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1665541677"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 5600,
-        "market_cap_rank": 1223,
-        "coingecko_rank": 1464,
-        "coingecko_score": 18.001,
-        "developer_score": 0,
-        "community_score": 9.623,
-        "liquidity_score": 21.024,
-        "public_interest_score": 0.014,
-        "market_data": {
-            "current_price": {
-                "usd": 0.061024
-            },
-            "total_value_locked": {
-                "usd": 72656545
-            },
-            "mcap_to_tvl_ratio": 0.06,
-            "fdv_to_tvl_ratio": 0.83,
-            "roi": null,
-            "ath": {
-                "usd": 0.297217
-            },
-            "ath_change_percentage": {
-                "usd": -79.55661
-            },
-            "ath_date": {
-                "usd": "2023-03-20T16:14:36.301Z"
-            },
-            "atl": {
-                "usd": 0.051576
-            },
-            "atl_change_percentage": {
-                "usd": 17.80926
-            },
-            "atl_date": {
-                "usd": "2023-06-16T07:54:53.341Z"
-            },
-            "market_cap": {
-                "usd": 4549227
-            },
-            "market_cap_rank": 1223,
-            "fully_diluted_valuation": {
-                "usd": 60476964
-            },
-            "total_volume": {
-                "usd": 118534
-            },
-            "high_24h": {
-                "usd": 0.066881
-            },
-            "low_24h": {
-                "usd": 0.059973
-            },
-            "price_change_24h": -0.005293930959179601,
-            "price_change_percentage_24h": -7.98271,
-            "price_change_percentage_7d": 4.13574,
-            "price_change_percentage_14d": 1.28821,
-            "price_change_percentage_30d": -30.40507,
-            "price_change_percentage_60d": -55.00683,
-            "price_change_percentage_200d": -31.04291,
-            "price_change_percentage_1y": -44.34773,
-            "market_cap_change_24h": -387967.84810977,
-            "market_cap_change_percentage_24h": -7.85806,
-            "price_change_24h_in_currency": {
-                "usd": -0.005293930959179579
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 1.75222
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -7.98271
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 4.13574
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 1.28821
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -30.40507
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -55.00683
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -31.04291
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -44.34773
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -387967.8481097659
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -7.85806
-            },
-            "total_supply": 1000000000,
-            "max_supply": 1000000000,
-            "circulating_supply": 75222483.07101855,
-            "last_updated": "2023-06-27T11:47:41.449Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:47:41.449Z"
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+    "sentiment_votes_up_percentage": 80,
+    "sentiment_votes_down_percentage": 20,
+    "watchlist_portfolio_users": 21665,
+    "market_cap_rank": 584,
+    "coingecko_rank": 1044,
+    "coingecko_score": 21.093,
+    "developer_score": 0,
+    "community_score": 9.422,
+    "liquidity_score": 30.295,
+    "public_interest_score": 0.002,
+    "market_data": {
+      "current_price": {
+        "usd": 14.82
+      },
+      "total_value_locked": {
+        "usd": 71190241
+      },
+      "mcap_to_tvl_ratio": 0.39,
+      "fdv_to_tvl_ratio": 0.5,
+      "roi": null,
+      "ath": {
+        "usd": 2066.2
+      },
+      "ath_change_percentage": {
+        "usd": -99.28216
+      },
+      "ath_date": {
+        "usd": "2021-03-20T19:33:19.740Z"
+      },
+      "atl": {
+        "usd": 12.84
+      },
+      "atl_change_percentage": {
+        "usd": 15.53178
+      },
+      "atl_date": {
+        "usd": "2023-06-15T11:31:15.772Z"
+      },
+      "market_cap": {
+        "usd": 27622772
+      },
+      "market_cap_rank": 584,
+      "fully_diluted_valuation": {
+        "usd": 35542295
+      },
+      "total_volume": {
+        "usd": 716868
+      },
+      "high_24h": {
+        "usd": 14.86
+      },
+      "low_24h": {
+        "usd": 14.21
+      },
+      "price_change_24h": 0.574299,
+      "price_change_percentage_24h": 4.03012,
+      "price_change_percentage_7d": -3.89521,
+      "price_change_percentage_14d": 8.40127,
+      "price_change_percentage_30d": -13.77062,
+      "price_change_percentage_60d": -16.22147,
+      "price_change_percentage_200d": -9.95935,
+      "price_change_percentage_1y": -37.3522,
+      "market_cap_change_24h": 1110111,
+      "market_cap_change_percentage_24h": 4.1871,
+      "price_change_24h_in_currency": {
+        "usd": 0.574299
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.30022
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 4.03012
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -3.89521
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 8.40127
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -13.77062
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -16.22147
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -9.95935
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -37.3522
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 1110111
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.1871
+      },
+      "total_supply": 2661168.51872948,
+      "max_supply": 2393060,
+      "circulating_supply": 1859839.1675733193,
+      "last_updated": "2023-07-03T17:46:26.171Z"
     },
-    {
-        "id": "ice-token",
-        "symbol": "ice",
-        "name": "Popsicle Finance",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xf16e81dce15b08f326220742020379b855b87df9",
-            "fantom": "0xf16e81dce15b08f326220742020379b855b87df9",
-            "binance-smart-chain": "0xf16e81dce15b08f326220742020379b855b87df9",
-            "polygon-pos": "0x4e1581f01046efdd7a1a2cdb0f82cdd7f71f2e59"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x4e1581f01046efdd7a1a2cdb0f82cdd7f71f2e59"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Polygon Ecosystem",
-            "BNB Chain Ecosystem",
-            "Fantom Ecosystem",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "A next-gen cross-chain yield enhancement platform focusing on Automated Market-Making (AMM) Liquidity Providers (LP)"
-        },
-        "links": {
-            "homepage": [
-                "https://popsicle.finance/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xf16e81dce15b08f326220742020379b855b87df9",
-                "https://ethplorer.io/address/0xf16e81dce15b08f326220742020379b855b87df9",
-                "https://bscscan.com/token/0xf16e81dce15b08f326220742020379b855b87df9",
-                "https://polygonscan.com/token/0x4e1581f01046efdd7a1a2cdb0f82cdd7f71f2e59",
-                "https://ftmscan.com/token/0xf16e81dce15b08f326220742020379b855b87df9",
-                "https://scan.meter.io/address/0xf16e81dce15b08f326220742020379b855b87df9",
-                "https://ftmscan.com/address/0xf16e81dce15b08f326220742020379b855b87df9",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/GDwhREgj5E",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://popsiclefinance.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "PopsicleFinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/Popsicle-Finance/"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14586/thumb/ice.png?1617188825",
-            "small": "https://assets.coingecko.com/coins/images/14586/small/ice.png?1617188825",
-            "large": "https://assets.coingecko.com/coins/images/14586/large/ice.png?1617188825"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9",
-        "sentiment_votes_up_percentage": 33.33,
-        "sentiment_votes_down_percentage": 66.67,
-        "watchlist_portfolio_users": 20471,
-        "market_cap_rank": 731,
-        "coingecko_rank": 1801,
-        "coingecko_score": 16.02,
-        "developer_score": 0,
-        "community_score": 9.457,
-        "liquidity_score": 13.385,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 1.14
-            },
-            "total_value_locked": {
-                "usd": 1118351
-            },
-            "mcap_to_tvl_ratio": 15.84,
-            "fdv_to_tvl_ratio": 24.62,
-            "roi": null,
-            "ath": {
-                "usd": 66.04
-            },
-            "ath_change_percentage": {
-                "usd": -98.27453
-            },
-            "ath_date": {
-                "usd": "2021-11-06T18:39:46.590Z"
-            },
-            "atl": {
-                "usd": 0.093364
-            },
-            "atl_change_percentage": {
-                "usd": 1120.55388
-            },
-            "atl_date": {
-                "usd": "2022-12-19T20:32:12.193Z"
-            },
-            "market_cap": {
-                "usd": 17714260
-            },
-            "market_cap_rank": 731,
-            "fully_diluted_valuation": {
-                "usd": 27534890
-            },
-            "total_volume": {
-                "usd": 474863
-            },
-            "high_24h": {
-                "usd": 1.25
-            },
-            "low_24h": {
-                "usd": 1.11
-            },
-            "price_change_24h": -0.04537773871727,
-            "price_change_percentage_24h": -3.8245,
-            "price_change_percentage_7d": 39.19795,
-            "price_change_percentage_14d": 31.16025,
-            "price_change_percentage_30d": -12.18797,
-            "price_change_percentage_60d": -22.24037,
-            "price_change_percentage_200d": 742.36333,
-            "price_change_percentage_1y": 239.74572,
-            "market_cap_change_24h": -1086857.3749427,
-            "market_cap_change_percentage_24h": -5.78081,
-            "price_change_24h_in_currency": {
-                "usd": -0.04537773871726891
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 1.88336
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -3.8245
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 39.19795
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 31.16025
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -12.18797
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -22.24037
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 742.36333
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 239.74572
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -1086857.3749427758
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -5.78081
-            },
-            "total_supply": 24157859,
-            "max_supply": null,
-            "circulating_supply": 15541684.8883019,
-            "last_updated": "2023-06-27T11:47:55.624Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:47:55.624Z"
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
     },
-    {
-        "id": "liquity",
-        "symbol": "lqty",
-        "name": "Liquity",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-            "arbitrum-one": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Arbitrum Ecosystem",
-            "Ethereum Ecosystem",
-            "Lending/Borrowing",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "LQTY is a token that captures the fee revenue generated by the Liquity Protocol via staking. Liquity is a decentralized borrowing protocol that allows you to draw 0% interest loans against Ether used as collateral. Loans are paid out in LUSD and need to maintain a minimum collateral ratio of only 110%.\r\n\r\nIn addition to the collateral, the loans are secured by a Stability Pool containing LUSD and by fellow borrowers collectively acting as guarantors of last resort. \r\n\r\nLiquity as a protocol is non-custodial, immutable, and governance-free."
-        },
-        "links": {
-            "homepage": [
-                "https://www.liquity.org/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
-                "https://ethplorer.io/address/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-                "https://arbiscan.io/token/0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
-                "https://arbiscan.io/token/0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/2up5U32",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/liquity",
-                ""
-            ],
-            "twitter_screen_name": "LiquityProtocol",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": "https://www.reddit.com\\/r/Liquity/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/liquity/dev"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180",
-            "small": "https://assets.coingecko.com/coins/images/14665/small/200-lqty-icon.png?1617631180",
-            "large": "https://assets.coingecko.com/coins/images/14665/large/200-lqty-icon.png?1617631180"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 14787,
-        "market_cap_rank": 284,
-        "coingecko_rank": 680,
-        "coingecko_score": 24.861,
-        "developer_score": 0,
-        "community_score": 27.187,
-        "liquidity_score": 27.034,
-        "public_interest_score": 0.003,
-        "market_data": {
-            "current_price": {
-                "usd": 0.946611
-            },
-            "total_value_locked": {
-                "usd": 741300584
-            },
-            "mcap_to_tvl_ratio": 0.12,
-            "fdv_to_tvl_ratio": 0.13,
-            "roi": null,
-            "ath": {
-                "usd": 146.94
-            },
-            "ath_change_percentage": {
-                "usd": -99.35738
-            },
-            "ath_date": {
-                "usd": "2021-04-05T21:48:37.754Z"
-            },
-            "atl": {
-                "usd": 0.54399
-            },
-            "atl_change_percentage": {
-                "usd": 73.58365
-            },
-            "atl_date": {
-                "usd": "2022-11-14T07:05:51.360Z"
-            },
-            "market_cap": {
-                "usd": 87319204
-            },
-            "market_cap_rank": 284,
-            "fully_diluted_valuation": {
-                "usd": 94290594
-            },
-            "total_volume": {
-                "usd": 8644134
-            },
-            "high_24h": {
-                "usd": 0.972524
-            },
-            "low_24h": {
-                "usd": 0.919509
-            },
-            "price_change_24h": -0.022164262287092,
-            "price_change_percentage_24h": -2.28787,
-            "price_change_percentage_7d": 13.80174,
-            "price_change_percentage_14d": 7.55324,
-            "price_change_percentage_30d": -24.48556,
-            "price_change_percentage_60d": -47.13828,
-            "price_change_percentage_200d": 56.57231,
-            "price_change_percentage_1y": -13.0588,
-            "market_cap_change_24h": -2789222.5985322,
-            "market_cap_change_percentage_24h": -3.09541,
-            "price_change_24h_in_currency": {
-                "usd": -0.022164262287091896
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.31187
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -2.28787
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 13.80174
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 7.55324
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -24.48556
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -47.13828
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 56.57231
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -13.0588
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -2789222.59853217
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -3.09541
-            },
-            "total_supply": 100000000,
-            "max_supply": 100000000,
-            "circulating_supply": 92606483.4489622,
-            "last_updated": "2023-06-27T11:49:28.838Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:28.838Z"
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:26.171Z"
+  },
+  {
+    "id": "alchemix-usd",
+    "symbol": "alusd",
+    "name": "Alchemix USD",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9",
+      "optimistic-ethereum": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a",
+      "fantom": "0xb67fa6defce4042070eb1ae1511dcd6dcc6a532e"
     },
-    {
-        "id": "liquity-usd",
-        "symbol": "lusd",
-        "name": "Liquity USD",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
-            "arbitrum-one": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
-            "polygon-pos": "0x23001f892c0c82b79303edc9b9033cd190bb21c7",
-            "optimistic-ethereum": "0xc40f949f8a4e094d1b49a23ea9241d289b7b2819"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x23001f892c0c82b79303edc9b9033cd190bb21c7"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xc40f949f8a4e094d1b49a23ea9241d289b7b2819"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Arbitrum Ecosystem",
-            "Optimism Ecosystem",
-            "Polygon Ecosystem",
-            "Ethereum Ecosystem",
-            "USD Stablecoin",
-            "Stablecoins",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "LUSD is a fully redeemable USD-pegged stablecoin issued by the Liquity Protocol. Liquity is a decentralized borrowing protocol that allows you to draw 0% interest loans against Ether used as collateral. Loans are paid out in LUSD and need to maintain a minimum collateral ratio of only 110%.\r\n\r\nIn addition to the collateral, the loans are secured by a Stability Pool containing LUSD and by fellow borrowers collectively acting as guarantors of last resort. \r\n\r\nLiquity as a protocol is non-custodial, immutable, and governance-free."
-        },
-        "links": {
-            "homepage": [
-                "https://www.liquity.org/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
-                "https://ethplorer.io/address/0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
-                "https://polygonscan.com/token/0x23001f892c0c82b79303edc9b9033cd190bb21c7",
-                "https://optimistic.etherscan.io/token/0xc40f949f8a4e094d1b49a23ea9241d289b7b2819",
-                "https://arbiscan.io/token/0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "",
-                "https://discord.gg/2up5U32",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/liquity",
-                ""
-            ],
-            "twitter_screen_name": "LiquityProtocol",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": "https://www.reddit.com/r/Liquity/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/liquity/dev"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
-            "small": "https://assets.coingecko.com/coins/images/14666/small/Group_3.png?1617631327",
-            "large": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1617631327"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 3152,
-        "market_cap_rank": 123,
-        "coingecko_rank": 490,
-        "coingecko_score": 27.776,
-        "developer_score": 0,
-        "community_score": 27.183,
-        "liquidity_score": 37.699,
-        "public_interest_score": 0.003,
-        "market_data": {
-            "current_price": {
-                "usd": 1.002
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1.16
-            },
-            "ath_change_percentage": {
-                "usd": -13.66628
-            },
-            "ath_date": {
-                "usd": "2021-04-05T14:47:52.665Z"
-            },
-            "atl": {
-                "usd": 0.896722
-            },
-            "atl_change_percentage": {
-                "usd": 11.52002
-            },
-            "atl_date": {
-                "usd": "2022-01-27T09:42:06.510Z"
-            },
-            "market_cap": {
-                "usd": 283205020
-            },
-            "market_cap_rank": 123,
-            "fully_diluted_valuation": {
-                "usd": 283205020
-            },
-            "total_volume": {
-                "usd": 6970118
-            },
-            "high_24h": {
-                "usd": 1.006
-            },
-            "low_24h": {
-                "usd": 0.996128
-            },
-            "price_change_24h": 0.00011594,
-            "price_change_percentage_24h": 0.01157,
-            "price_change_percentage_7d": -0.69091,
-            "price_change_percentage_14d": -0.60126,
-            "price_change_percentage_30d": -0.79699,
-            "price_change_percentage_60d": -0.70301,
-            "price_change_percentage_200d": -2.7543,
-            "price_change_percentage_1y": -1.81778,
-            "market_cap_change_24h": -1489537.052665,
-            "market_cap_change_percentage_24h": -0.52321,
-            "price_change_24h_in_currency": {
-                "usd": 0.00011594
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.34365
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 0.01157
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -0.69091
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -0.60126
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -0.79699
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -0.70301
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -2.7543
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -1.81778
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -1489537.0526648164
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.52321
-            },
-            "total_supply": 282624081.429826,
-            "max_supply": null,
-            "circulating_supply": 282624090.231488,
-            "last_updated": "2023-06-27T11:49:14.070Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:14.070Z"
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0xb67fa6defce4042070eb1ae1511dcd6dcc6a532e"
+      }
     },
-    {
-        "id": "magic-internet-money",
-        "symbol": "mim",
-        "name": "Magic Internet Money",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
-            "optimistic-ethereum": "0xb153fb3d196a8eb25522705560ac152eeec57901",
-            "binance-smart-chain": "0xfe19f0b51438fd612f6fd59c1dbb3ea319f433ba",
-            "avalanche": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-            "moonriver": "0x0cae51e1032e8461f4806e26332c030e34de3adb",
-            "arbitrum-one": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
-            "fantom": "0x82f0b8b456c1a451378467398982d4834b6829c1",
-            "polygon-pos": "0x49a0400587a7f65072c87c4910449fdcc5c47242"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3"
-            },
-            "optimistic-ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xb153fb3d196a8eb25522705560ac152eeec57901"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xfe19f0b51438fd612f6fd59c1dbb3ea319f433ba"
-            },
-            "avalanche": {
-                "decimal_place": 18,
-                "contract_address": "0x130966628846bfd36ff31a822705796e8cb8c18d"
-            },
-            "moonriver": {
-                "decimal_place": 18,
-                "contract_address": "0x0cae51e1032e8461f4806e26332c030e34de3adb"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a"
-            },
-            "fantom": {
-                "decimal_place": 18,
-                "contract_address": "0x82f0b8b456c1a451378467398982d4834b6829c1"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x49a0400587a7f65072c87c4910449fdcc5c47242"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Optimism Ecosystem",
-            "USD Stablecoin",
-            "BNB Chain Ecosystem",
-            "Ethereum Ecosystem",
-            "Fantom Ecosystem",
-            "Arbitrum Ecosystem",
-            "Polygon Ecosystem",
-            "Moonriver Ecosystem",
-            "Avalanche Ecosystem",
-            "Stablecoins",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Abracadabra.money is a lending platform that allows users to mint the Stablecoin MIM using interest bearing tokens as collaterals!"
-        },
-        "links": {
-            "homepage": [
-                "https://abracadabra.money/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
-                "https://ethplorer.io/address/0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
-                "https://arbiscan.io/token/0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
-                "https://avascan.info/blockchain/c/address/0x130966628846bfd36ff31a822705796e8cb8c18d",
-                "https://snowtrace.io/token/0x130966628846bfd36ff31a822705796e8cb8c18d",
-                "https://moonriver.moonscan.io/token/0x0cae51e1032e8461f4806e26332c030e34de3adb",
-                "https://polygonscan.com/token/0x49a0400587a7f65072c87c4910449fdcc5c47242",
-                "https://ftmscan.com/token/0x82f0b8b456c1a451378467398982d4834b6829c1",
-                "https://scan.meter.io/address/0x82f0b8b456c1a451378467398982d4834b6829c1",
-                "https://ftmscan.com/address/0x82f0b8b456c1a451378467398982d4834b6829c1"
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.gg/wcsUNxYrFM",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://abracadabramoney.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "MIM_Spell",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "abracadabramoney",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/Abracadabra-money/magic-internet-money"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
-            "small": "https://assets.coingecko.com/coins/images/16786/small/mimlogopng.png?1624979612",
-            "large": "https://assets.coingecko.com/coins/images/16786/large/mimlogopng.png?1624979612"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 11865,
-        "market_cap_rank": 286,
-        "coingecko_rank": 821,
-        "coingecko_score": 23.04,
-        "developer_score": 0,
-        "community_score": 9.947,
-        "liquidity_score": 32.321,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 0.997935
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1.041
-            },
-            "ath_change_percentage": {
-                "usd": -4.11768
-            },
-            "ath_date": {
-                "usd": "2021-10-06T13:25:17.751Z"
-            },
-            "atl": {
-                "usd": 0.876409
-            },
-            "atl_change_percentage": {
-                "usd": 13.89518
-            },
-            "atl_date": {
-                "usd": "2023-03-11T08:02:51.714Z"
-            },
-            "market_cap": {
-                "usd": 86003319
-            },
-            "market_cap_rank": 286,
-            "fully_diluted_valuation": {
-                "usd": 134306806
-            },
-            "total_volume": {
-                "usd": 826098
-            },
-            "high_24h": {
-                "usd": 1.002
-            },
-            "low_24h": {
-                "usd": 0.994532
-            },
-            "price_change_24h": -0.000431518819329,
-            "price_change_percentage_24h": -0.04322,
-            "price_change_percentage_7d": -0.11268,
-            "price_change_percentage_14d": -0.40585,
-            "price_change_percentage_30d": -0.20559,
-            "price_change_percentage_60d": -0.25637,
-            "price_change_percentage_200d": -0.12992,
-            "price_change_percentage_1y": 0.36852,
-            "market_cap_change_24h": -168892.4089102,
-            "market_cap_change_percentage_24h": -0.19599,
-            "price_change_24h_in_currency": {
-                "usd": -0.000431518819329568
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.13096
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.04322
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -0.11268
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -0.40585
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -0.20559
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -0.25637
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -0.12992
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 0.36852
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -168892.4089101404
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.19599
-            },
-            "total_supply": 134730988.524743,
-            "max_supply": null,
-            "circulating_supply": 86274944.836057,
-            "last_updated": "2023-06-27T11:49:37.125Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:37.125Z"
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Fantom Ecosystem",
+      "Optimism Ecosystem",
+      "Ethereum Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "USD Stablecoin",
+      "Stablecoins"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "alUSD is a yield-backed synthetic stablecoin powered by the Alchemix protocol"
     },
-    {
-        "id": "manifold-finance",
-        "symbol": "fold",
-        "name": "Manifold Finance",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "MEV Protection"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Manifold Finance provides solutions encompassing the middleware market for decentralized finance applications and protocols for both scaling and usability purposes. Part of our mission is helping scale the Ethereum ecosystem, which is where the idea of ‘middleware strategies’ comes into play. Our solutions can be thought of as an ‘APY strategy’ that you might find with something like Yearn Finance, except instead of providing capital (e.g. through depositing into a strategy with Yearn), we create applications that provide services that generate revenue (a prime example being YCabal)."
-        },
-        "links": {
-            "homepage": [
-                "https://www.manifoldfinance.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
-                "https://ethplorer.io/address/0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/manifoldfinance",
-                ""
-            ],
-            "twitter_screen_name": "foldfinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "manifoldfinance",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/manifoldfinance"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/15928/thumb/Manifold.png?1622439811",
-            "small": "https://assets.coingecko.com/coins/images/15928/small/Manifold.png?1622439811",
-            "large": "https://assets.coingecko.com/coins/images/15928/large/Manifold.png?1622439811"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 5544,
-        "market_cap_rank": 604,
-        "coingecko_rank": 825,
-        "coingecko_score": 22.954,
-        "developer_score": 0,
-        "community_score": 7.985,
-        "liquidity_score": 36.814,
-        "public_interest_score": 0.002,
-        "market_data": {
-            "current_price": {
-                "usd": 15.23
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 103.27
-            },
-            "ath_change_percentage": {
-                "usd": -85.27935
-            },
-            "ath_date": {
-                "usd": "2022-09-15T08:04:06.379Z"
-            },
-            "atl": {
-                "usd": 3.83
-            },
-            "atl_change_percentage": {
-                "usd": 297.36779
-            },
-            "atl_date": {
-                "usd": "2021-07-21T01:29:39.734Z"
-            },
-            "market_cap": {
-                "usd": 25309617
-            },
-            "market_cap_rank": 604,
-            "fully_diluted_valuation": {
-                "usd": 30405636
-            },
-            "total_volume": {
-                "usd": 176819
-            },
-            "high_24h": {
-                "usd": 15.74
-            },
-            "low_24h": {
-                "usd": 13.84
-            },
-            "price_change_24h": -0.5046288973942,
-            "price_change_percentage_24h": -3.20801,
-            "price_change_percentage_7d": 14.33016,
-            "price_change_percentage_14d": 19.32925,
-            "price_change_percentage_30d": -2.27543,
-            "price_change_percentage_60d": -30.73151,
-            "price_change_percentage_200d": 14.85383,
-            "price_change_percentage_1y": 62.68758,
-            "market_cap_change_24h": -866888.6251025,
-            "market_cap_change_percentage_24h": -3.3117,
-            "price_change_24h_in_currency": {
-                "usd": -0.5046288973942037
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.06431
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -3.20801
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 14.33016
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 19.32925
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -2.27543
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -30.73151
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 14.85383
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 62.68758
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -866888.6251024865
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -3.3117
-            },
-            "total_supply": 2000000,
-            "max_supply": 2000000,
-            "circulating_supply": 1664797.7597608927,
-            "last_updated": "2023-06-27T11:49:37.279Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:37.279Z"
+    "links": {
+      "homepage": ["https://alchemix.fi/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9",
+        "https://ethplorer.io/address/0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9",
+        "https://optimistic.etherscan.io/token/0xCB8FA9a76b8e203D8C3797bF438d8FB81Ea3326A",
+        "https://ftmscan.com/token/0xB67FA6deFCe4042070Eb1ae1511Dcd6dcc6a532E",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/qWfMzCmSHX", "", ""],
+      "announcement_url": ["https://alchemixfi.medium.com/", ""],
+      "twitter_screen_name": "AlchemixFi",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/alchemix-finance"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "matic-network",
-        "symbol": "matic",
-        "name": "Polygon",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-            "polygon-pos": "0x0000000000000000000000000000000000001010",
-            "harmony-shard-0": "0x301259f392b551ca8c592c9f676fcd2f9a0a84c5",
-            "binance-smart-chain": "0xcc42724c6683b7e57334c4e856f4c9965ed682bd",
-            "moonriver": "0x682f81e57eaa716504090c3ecba8595fb54561d8",
-            "sora": "0x009134d5c7b7fda8863985531f456f89bef5fbd76684a8acdb737b3e451d0877",
-            "moonbeam": "0x3405a1bd46b85c5c029483fbecf2f3e611026e45",
-            "energi": "0x98997e1651919faeacee7b96afbb3dfd96cb6036"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x0000000000000000000000000000000000001010"
-            },
-            "harmony-shard-0": {
-                "decimal_place": 18,
-                "contract_address": "0x301259f392b551ca8c592c9f676fcd2f9a0a84c5"
-            },
-            "binance-smart-chain": {
-                "decimal_place": 18,
-                "contract_address": "0xcc42724c6683b7e57334c4e856f4c9965ed682bd"
-            },
-            "moonriver": {
-                "decimal_place": 18,
-                "contract_address": "0x682f81e57eaa716504090c3ecba8595fb54561d8"
-            },
-            "sora": {
-                "decimal_place": 18,
-                "contract_address": "0x009134d5c7b7fda8863985531f456f89bef5fbd76684a8acdb737b3e451d0877"
-            },
-            "moonbeam": {
-                "decimal_place": 18,
-                "contract_address": "0x3405a1bd46b85c5c029483fbecf2f3e611026e45"
-            },
-            "energi": {
-                "decimal_place": 18,
-                "contract_address": "0x98997e1651919faeacee7b96afbb3dfd96cb6036"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Zero Knowledge (ZK)",
-            "Layer 2 (L2)",
-            "Harmony Ecosystem",
-            "Ethereum Ecosystem",
-            "Moonbeam Ecosystem",
-            "Moonriver Ecosystem",
-            "BNB Chain Ecosystem",
-            "Smart Contract Platform",
-            "Polygon Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Polygon (Previously Matic Network) is the first well-structured, easy-to-use platform for Ethereum scaling and infrastructure development. Its core component is Polygon SDK, a modular, flexible framework that supports building multiple types of applications.\r\n\r\nUsing Polygon, one can create Optimistic Rollup chains, ZK Rollup chains, stand alone chains or any other kind of infra required by the developer. \r\n\r\nPolygon effectively transforms Ethereum into a full-fledged multi-chain system (aka Internet of Blockchains). This multi-chain system is akin to other ones such as Polkadot, Cosmos, Avalanche etc with the advantages of Ethereum’s security, vibrant ecosystem and openness.\r\n\r\nNothing will change for the existing ecosystem built on the Plasma-POS chain. With Polygon, new features are being built around the existing proven technology to expand the ability to cater to diverse needs from the developer ecosystem. Polygon will continue to develop the core technology so that it can scale to a larger ecosystem. \r\n\r\nThe $MATIC token will continue to exist and will play an increasingly important role, securing the system and enabling governance."
-        },
-        "links": {
-            "homepage": [
-                "https://polygon.technology/",
-                "https://blog.polygon.technology/",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-                "https://ethplorer.io/address/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-                "https://polygonscan.com/token/0x0000000000000000000000000000000000001010",
-                "https://bscscan.com/token/0xCC42724C6683B7E57334c4E856f4c9965ED682bD",
-                "https://moonriver.moonscan.io/token/0x682f81e57eaa716504090c3ecba8595fb54561d8",
-                "https://moonbeam.moonscan.io/token/0x3405A1bd46B85c5C029483FbECf2F3E611026e45",
-                "https://explorer.energi.network/token/0x98997e1651919faeacee7b96afbb3dfd96cb6036",
-                "https://www.oklink.com/polygon",
-                "https://3xpl.com/polygon",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "",
-                "https://discord.com/invite/XvpHAxZ",
-                "https://t.me/PolygonAnnouncements"
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "0xPolygon",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "polygonofficial",
-            "subreddit_url": "https://www.reddit.com/r/maticnetwork/",
-            "repos_url": {
-                "github": [
-                    "https://github.com/maticnetwork/contracts",
-                    "https://github.com/maticnetwork/heimdall",
-                    "https://github.com/maticnetwork/matic.js",
-                    "https://github.com/maticnetwork/eth-dagger.js",
-                    "https://github.com/maticnetwork/sol-trace"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
-            "small": "https://assets.coingecko.com/coins/images/4713/small/matic-token-icon.png?1624446912",
-            "large": "https://assets.coingecko.com/coins/images/4713/large/matic-token-icon.png?1624446912"
-        },
-        "country_origin": "IN",
-        "genesis_date": null,
-        "contract_address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-        "sentiment_votes_up_percentage": 78,
-        "sentiment_votes_down_percentage": 22,
-        "ico_data": {
-            "ico_start_date": null,
-            "ico_end_date": null,
-            "short_desc": "Scalable and Instant Blockchain Transactions",
-            "description": null,
-            "links": {},
-            "softcap_currency": "",
-            "hardcap_currency": "",
-            "total_raised_currency": "",
-            "softcap_amount": null,
-            "hardcap_amount": null,
-            "total_raised": null,
-            "quote_pre_sale_currency": "USD",
-            "base_pre_sale_amount": "1.0",
-            "quote_pre_sale_amount": "0.0026",
-            "quote_public_sale_currency": "USD",
-            "base_public_sale_amount": 1,
-            "quote_public_sale_amount": 0.00263,
-            "accepting_currencies": "",
-            "country_origin": "IN",
-            "pre_sale_start_date": null,
-            "pre_sale_end_date": null,
-            "whitelist_url": "",
-            "whitelist_start_date": null,
-            "whitelist_end_date": null,
-            "bounty_detail_url": "",
-            "amount_for_sale": null,
-            "kyc_required": true,
-            "whitelist_available": false,
-            "pre_sale_available": null,
-            "pre_sale_ended": false
-        },
-        "watchlist_portfolio_users": 534197,
-        "market_cap_rank": 14,
-        "coingecko_rank": 66,
-        "coingecko_score": 48.86,
-        "developer_score": 62.496,
-        "community_score": 12.154,
-        "liquidity_score": 68.532,
-        "public_interest_score": 0.053,
-        "market_data": {
-            "current_price": {
-                "usd": 0.666405
-            },
-            "total_value_locked": {
-                "usd": 5619335605
-            },
-            "mcap_to_tvl_ratio": 1.1,
-            "fdv_to_tvl_ratio": 1.18,
-            "roi": {
-                "times": 252.38591974381788,
-                "currency": "usd",
-                "percentage": 25238.591974381787
-            },
-            "ath": {
-                "usd": 2.92
-            },
-            "ath_change_percentage": {
-                "usd": -77.22355
-            },
-            "ath_date": {
-                "usd": "2021-12-27T02:08:34.307Z"
-            },
-            "atl": {
-                "usd": 0.00314376
-            },
-            "atl_change_percentage": {
-                "usd": 21028.24243
-            },
-            "atl_date": {
-                "usd": "2019-05-10T00:00:00.000Z"
-            },
-            "market_cap": {
-                "usd": 6190199251
-            },
-            "market_cap_rank": 14,
-            "fully_diluted_valuation": {
-                "usd": 6642223076
-            },
-            "total_volume": {
-                "usd": 187550416
-            },
-            "high_24h": {
-                "usd": 0.669538
-            },
-            "low_24h": {
-                "usd": 0.639302
-            },
-            "price_change_24h": 0.00676393,
-            "price_change_percentage_24h": 1.0254,
-            "price_change_percentage_7d": 10.18595,
-            "price_change_percentage_14d": 2.74165,
-            "price_change_percentage_30d": -28.23518,
-            "price_change_percentage_60d": -33.44452,
-            "price_change_percentage_200d": -27.94327,
-            "price_change_percentage_1y": 12.49704,
-            "market_cap_change_24h": 57705413,
-            "market_cap_change_percentage_24h": 0.94098,
-            "price_change_24h_in_currency": {
-                "usd": 0.00676393
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.01525
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": 1.0254
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 10.18595
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 2.74165
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -28.23518
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -33.44452
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -27.94327
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 12.49704
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 57705413
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0.94098
-            },
-            "total_supply": 10000000000,
-            "max_supply": 10000000000,
-            "circulating_supply": 9319469069.28493,
-            "last_updated": "2023-06-27T11:49:32.859Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 55039,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:32.859Z"
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14114/thumb/Alchemix_USD.png?1614410406",
+      "small": "https://assets.coingecko.com/coins/images/14114/small/Alchemix_USD.png?1614410406",
+      "large": "https://assets.coingecko.com/coins/images/14114/large/Alchemix_USD.png?1614410406"
     },
-    {
-        "id": "metaverse-index",
-        "symbol": "mvi",
-        "name": "Metaverse Index",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
-            "polygon-pos": "0xfe712251173a2cd5f5be2b46bb528328ea3565e1"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0xfe712251173a2cd5f5be2b46bb528328ea3565e1"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "TokenSets",
-            "DeFi Index",
-            "Decentralized Finance (DeFi)",
-            "Structured Products",
-            "Polygon Ecosystem",
-            "Metaverse",
-            "Ethereum Ecosystem",
-            "Index",
-            "NFT Index"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "The Metaverse Index is designed to capture the trend of entertainment, sports and business shifting to a virtual environment, with economic activity in this environment taking place on the Ethereum blockchain.\r\n"
-        },
-        "links": {
-            "homepage": [
-                "https://indexcoop.com/products/metaverse-index",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x72e364f2abdc788b7e918bc238b21f109cd634d7",
-                "https://ethplorer.io/address/0x72e364f2abdc788b7e918bc238b21f109cd634d7",
-                "https://polygonscan.com/token/0xfe712251173a2cd5f5be2b46bb528328ea3565e1",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/indexcoop",
-                "https://www.youtube.com/channel/UCsNqHm_2LKh0E4A0vf25pIw",
-                ""
-            ],
-            "announcement_url": [
-                "https://indexcoop.com/blog",
-                ""
-            ],
-            "twitter_screen_name": "indexcoop",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14684/thumb/MVI_logo.png?1617776444",
-            "small": "https://assets.coingecko.com/coins/images/14684/small/MVI_logo.png?1617776444",
-            "large": "https://assets.coingecko.com/coins/images/14684/large/MVI_logo.png?1617776444"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 12108,
-        "market_cap_rank": 1519,
-        "coingecko_rank": 2144,
-        "coingecko_score": 14.308,
-        "developer_score": 0,
-        "community_score": 9.188,
-        "liquidity_score": 3.744,
-        "public_interest_score": 0.003,
-        "market_data": {
-            "current_price": {
-                "usd": 15.14
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 372.65
-            },
-            "ath_change_percentage": {
-                "usd": -95.93026
-            },
-            "ath_date": {
-                "usd": "2021-11-25T10:15:50.405Z"
-            },
-            "atl": {
-                "usd": 12.88
-            },
-            "atl_change_percentage": {
-                "usd": 17.70686
-            },
-            "atl_date": {
-                "usd": "2023-06-14T21:04:06.935Z"
-            },
-            "market_cap": {
-                "usd": 2510845
-            },
-            "market_cap_rank": 1519,
-            "fully_diluted_valuation": {
-                "usd": 2510845
-            },
-            "total_volume": {
-                "usd": 2649.54
-            },
-            "high_24h": {
-                "usd": 15.84
-            },
-            "low_24h": {
-                "usd": 14.91
-            },
-            "price_change_24h": -0.5098021466908,
-            "price_change_percentage_24h": -3.2586,
-            "price_change_percentage_7d": 8.92832,
-            "price_change_percentage_14d": 3.97803,
-            "price_change_percentage_30d": -21.86675,
-            "price_change_percentage_60d": -33.30816,
-            "price_change_percentage_200d": -26.08335,
-            "price_change_percentage_1y": -64.94838,
-            "market_cap_change_24h": -78282.53780822,
-            "market_cap_change_percentage_24h": -3.02351,
-            "price_change_24h_in_currency": {
-                "usd": -0.5098021466908467
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.42359
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -3.2586
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 8.92832
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 3.97803
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -21.86675
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -33.30816
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -26.08335
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -64.94838
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -78282.53780822456
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -3.02351
-            },
-            "total_supply": 165560.26743571,
-            "max_supply": null,
-            "circulating_supply": 165560.26743571,
-            "last_updated": "2023-06-27T11:44:43.442Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:44:43.442Z"
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xbc6da0fe9ad5f3b0d58160288917aa56653660e9",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 1072,
+    "market_cap_rank": 186,
+    "coingecko_rank": 1099,
+    "coingecko_score": 20.783,
+    "developer_score": 0,
+    "community_score": 9.422,
+    "liquidity_score": 22.161,
+    "public_interest_score": 0.002,
+    "market_data": {
+      "current_price": {
+        "usd": 0.997488
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 2.13
+      },
+      "ath_change_percentage": {
+        "usd": -53.13082
+      },
+      "ath_date": {
+        "usd": "2021-03-21T19:53:32.860Z"
+      },
+      "atl": {
+        "usd": 0.060239
+      },
+      "atl_change_percentage": {
+        "usd": 1555.18497
+      },
+      "atl_date": {
+        "usd": "2021-03-19T22:40:28.697Z"
+      },
+      "market_cap": {
+        "usd": 170941466
+      },
+      "market_cap_rank": 186,
+      "fully_diluted_valuation": {
+        "usd": 170940519
+      },
+      "total_volume": {
+        "usd": 126034
+      },
+      "high_24h": {
+        "usd": 1.004
+      },
+      "low_24h": {
+        "usd": 0.992629
+      },
+      "price_change_24h": -0.002900927995281,
+      "price_change_percentage_24h": -0.28998,
+      "price_change_percentage_7d": -0.53616,
+      "price_change_percentage_14d": -0.05301,
+      "price_change_percentage_30d": 0.21655,
+      "price_change_percentage_60d": -0.29111,
+      "price_change_percentage_200d": 1.06614,
+      "price_change_percentage_1y": 1.14857,
+      "market_cap_change_24h": -577090.508158,
+      "market_cap_change_percentage_24h": -0.33646,
+      "price_change_24h_in_currency": {
+        "usd": -0.002900927995276304
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.0222
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": -0.28998
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.53616
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -0.05301
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 0.21655
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -0.29111
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 1.06614
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 1.14857
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": -577090.5081582665
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -0.33646
+      },
+      "total_supply": 171473694.782216,
+      "max_supply": null,
+      "circulating_supply": 171474644.782216,
+      "last_updated": "2023-07-03T17:46:34.653Z"
     },
-   
-    {
-        "id": "monerium-eur-money",
-        "symbol": "eure",
-        "name": "Monerium EUR emoney",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x3231cb76718cdef2155fc47b5286d82e6eda273f",
-            "polygon-pos": "0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6",
-            "xdai": "0xcb444e90d8198415266c6a2724b7900fb12fc56e"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x3231cb76718cdef2155fc47b5286d82e6eda273f"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6"
-            },
-            "xdai": {
-                "decimal_place": 18,
-                "contract_address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Polygon Ecosystem",
-            "Gnosis Chain Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Stablecoins",
-            "EUR Stablecoin",
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [
-            "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
-        ],
-        "description": {
-            "en": "Monerium is the first and, to date, only company authorized to issue money on blockchains under current European financial regulation and proposed Market in Crypto-Assets regulation. We have issued EUR, USD, GBP, and ISK as e-money tokens on Ethereum and EUR on Algorand. Monerium also operates a gateway for instant transfers of EUR between bank accounts and blockchain wallets / smart contracts. Founded by crypto OGs and repeat entrepreneurs, Monerium is backed by Taavet+Sten, Crowberry Capital, ConsenSys, Algorand, and several entrepreneurs and early crypto adopters. "
-        },
-        "links": {
-            "homepage": [
-                "https://monerium.com/tokens/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x3231cb76718cdef2155fc47b5286d82e6eda273f",
-                "https://ethplorer.io/address/0x3231cb76718cdef2155fc47b5286d82e6eda273f",
-                "https://polygonscan.com/token/0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6",
-                "https://gnosisscan.io/token/0xcB444e90D8198415266c6a2724b7900fb12FC56E",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/@monerium",
-                ""
-            ],
-            "twitter_screen_name": "monerium",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/monerium/smart-contracts"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/23354/thumb/eur.png?1643926562",
-            "small": "https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562",
-            "large": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1643926562"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x3231cb76718cdef2155fc47b5286d82e6eda273f",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 94,
-        "market_cap_rank": null,
-        "coingecko_rank": 2421,
-        "coingecko_score": 13.153,
-        "developer_score": 46.147,
-        "community_score": 6.438,
-        "liquidity_score": 1,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 1.091
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1.17
-            },
-            "ath_change_percentage": {
-                "usd": -6.57292
-            },
-            "ath_date": {
-                "usd": "2023-05-14T07:15:58.558Z"
-            },
-            "atl": {
-                "usd": 0.951958
-            },
-            "atl_change_percentage": {
-                "usd": 14.6331
-            },
-            "atl_date": {
-                "usd": "2022-09-06T17:31:09.870Z"
-            },
-            "market_cap": {
-                "usd": 0
-            },
-            "market_cap_rank": null,
-            "fully_diluted_valuation": {
-                "usd": 1181699
-            },
-            "total_volume": {
-                "usd": 59527
-            },
-            "high_24h": {
-                "usd": 1.1
-            },
-            "low_24h": {
-                "usd": 1.085
-            },
-            "price_change_24h": -0.00812225606371,
-            "price_change_percentage_24h": -0.73866,
-            "price_change_percentage_7d": 0.29806,
-            "price_change_percentage_14d": 0.89061,
-            "price_change_percentage_30d": 2.19952,
-            "price_change_percentage_60d": -0.59254,
-            "price_change_percentage_200d": 3.77123,
-            "price_change_percentage_1y": 0.78812,
-            "market_cap_change_24h": 0,
-            "market_cap_change_percentage_24h": 0,
-            "price_change_24h_in_currency": {
-                "usd": -0.008122256063712863
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": 0.13824
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.73866
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 0.29806
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 0.89061
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 2.19952
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -0.59254
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 3.77123
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 0.78812
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": 0
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0
-            },
-            "total_supply": 1083746,
-            "max_supply": 1083746,
-            "circulating_supply": 0,
-            "last_updated": "2023-06-27T11:48:09.145Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:48:09.145Z"
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
     },
-    {
-        "id": "origin-ether",
-        "symbol": "oeth",
-        "name": "Origin Ether",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Origin Ether (OETH) is a liquid staking yield aggregator on Ethereum. When staking ETH, there are various liquid staking derivatives (LSDs) to choose from, the largest being Lido, Coinbase, Rocket Pool, and Frax. OETH is an LSD aggregator that combines the yield-generating functions of the largest LSDs into one single token. OETH is permissionless, fully collateralized, self-custodial, passive, and fully transparent. There are no lock-ups or conditions required to earn yield, yield is distributed daily and automatically directly into users' wallets. Built by the team at Origin Protocol."
-        },
-        "links": {
-            "homepage": [
-                "https://oeth.com/",
-                "https://originprotocol.com/",
-                "https://ousd.com/"
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3",
-                "https://ethplorer.io/address/0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "https://www.tiktok.com/@origin_protocol",
-                "https://instagram.com/originprotocol",
-                "https://www.linkedin.com/company/originprotocol/"
-            ],
-            "chat_url": [
-                "https://discord.com/invite/ogn",
-                "https://blog.originprotocol.com/",
-                "https://www.youtube.com/c/originprotocol"
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "OriginProtocol",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "originprotocol",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/29733/thumb/OETH.png?1681094770",
-            "small": "https://assets.coingecko.com/coins/images/29733/small/OETH.png?1681094770",
-            "large": "https://assets.coingecko.com/coins/images/29733/large/OETH.png?1681094770"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 70,
-        "market_cap_rank": 493,
-        "coingecko_rank": null,
-        "coingecko_score": 0,
-        "developer_score": 0,
-        "community_score": 0,
-        "liquidity_score": 0,
-        "public_interest_score": 0,
-        "market_data": {
-            "current_price": {
-                "usd": 1871.74
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 1928.92
-            },
-            "ath_change_percentage": {
-                "usd": -2.76246
-            },
-            "ath_date": {
-                "usd": "2023-06-22T03:24:49.381Z"
-            },
-            "atl": {
-                "usd": 1625.4
-            },
-            "atl_change_percentage": {
-                "usd": 15.3951
-            },
-            "atl_date": {
-                "usd": "2023-06-15T09:33:43.370Z"
-            },
-            "market_cap": {
-                "usd": 36118797
-            },
-            "market_cap_rank": 493,
-            "fully_diluted_valuation": {
-                "usd": 36118797
-            },
-            "total_volume": {
-                "usd": 32133
-            },
-            "high_24h": {
-                "usd": 1905.12
-            },
-            "low_24h": {
-                "usd": 1845.57
-            },
-            "price_change_24h": -10.03067136363,
-            "price_change_percentage_24h": -0.53304,
-            "price_change_percentage_7d": 8.1802,
-            "price_change_percentage_14d": 6.84906,
-            "price_change_percentage_30d": 1.3729,
-            "price_change_percentage_60d": 0,
-            "price_change_percentage_200d": 0,
-            "price_change_percentage_1y": 0,
-            "market_cap_change_24h": 296886,
-            "market_cap_change_percentage_24h": 0.82878,
-            "price_change_24h_in_currency": {
-                "usd": -10.030671363638248
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.40659
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.53304
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 8.1802
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 6.84906
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 1.3729
-            },
-            "price_change_percentage_60d_in_currency": {},
-            "price_change_percentage_200d_in_currency": {},
-            "price_change_percentage_1y_in_currency": {},
-            "market_cap_change_24h_in_currency": {
-                "usd": 296886
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": 0.82878
-            },
-            "total_supply": 19248,
-            "max_supply": 19248,
-            "circulating_supply": 19248,
-            "last_updated": "2023-06-27T11:49:06.107Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:06.107Z"
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:34.653Z"
+  },
+  {
+    "id": "ampleforth",
+    "symbol": "ampl",
+    "name": "Ampleforth",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
+      "near-protocol": "77fba179c79de5b7653f68b5039af940ada60ce0.factory.bridge.near",
+      "harmony-shard-0": "0xf2f5bf00cd952f3f980a02f5dce278cbff4dae05",
+      "binance-smart-chain": "0xdb021b1b247fe2f1fa57e0a87c748cc1e321f07f",
+      "avalanche": "0x027dbca046ca156de9622cd1e2d907d375e53aa7",
+      "energi": "0x79786ed8a70ccec6c7a31debc7fefc5119f9dc95"
     },
-    {
-        "id": "reflexer-ungovernance-token",
-        "symbol": "flx",
-        "name": "Reflexer Ungovernance",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x6243d8cea23066d098a15582d81a598b4e8391f4"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x6243d8cea23066d098a15582d81a598b4e8391f4"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Decentralized Finance (DeFi)"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "FLX will have two different core functions:\r\n\r\n- Lender of last resort: similar to other models such as the Maker protocol, the RAI system will have surplus and debt auctions. Debt auctions will autonomously mint and auction new FLX in case the system is underwater.\r\n\r\n- Ungoverning the RAI system: once the vast majority of governance capabilities are completely removed from the system, the community will be able to decide on how, when and if to securely governance minimize any remaining components. FLX will facilitate further ungovernance and allow the community to take decisions on how to remove themselves from discretion over the protocol."
-        },
-        "links": {
-            "homepage": [
-                "https://reflexer.finance/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x6243d8cea23066d098a15582d81a598b4e8391f4",
-                "https://ethplorer.io/address/0x6243d8cea23066d098a15582d81a598b4e8391f4",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/83t3xKT",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "",
-                ""
-            ],
-            "twitter_screen_name": "reflexerfinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/reflexer-labs"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/14123/thumb/EAfYdwgd_400x400.jpg?1614564508",
-            "small": "https://assets.coingecko.com/coins/images/14123/small/EAfYdwgd_400x400.jpg?1614564508",
-            "large": "https://assets.coingecko.com/coins/images/14123/large/EAfYdwgd_400x400.jpg?1614564508"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x6243d8cea23066d098a15582d81a598b4e8391f4",
-        "sentiment_votes_up_percentage": null,
-        "sentiment_votes_down_percentage": null,
-        "watchlist_portfolio_users": 3718,
-        "market_cap_rank": 896,
-        "coingecko_rank": 1869,
-        "coingecko_score": 15.583,
-        "developer_score": 0,
-        "community_score": 8.384,
-        "liquidity_score": 7.57,
-        "public_interest_score": 0.001,
-        "market_data": {
-            "current_price": {
-                "usd": 15.5
-            },
-            "total_value_locked": {
-                "usd": 30507070
-            },
-            "mcap_to_tvl_ratio": 0.38,
-            "fdv_to_tvl_ratio": 0.5,
-            "roi": null,
-            "ath": {
-                "usd": 1839.79
-            },
-            "ath_change_percentage": {
-                "usd": -99.14344
-            },
-            "ath_date": {
-                "usd": "2021-04-15T20:14:47.371Z"
-            },
-            "atl": {
-                "usd": 9.73
-            },
-            "atl_change_percentage": {
-                "usd": 61.95938
-            },
-            "atl_date": {
-                "usd": "2023-01-25T01:31:38.657Z"
-            },
-            "market_cap": {
-                "usd": 11536918
-            },
-            "market_cap_rank": 896,
-            "fully_diluted_valuation": {
-                "usd": 15327240
-            },
-            "total_volume": {
-                "usd": 5754.06
-            },
-            "high_24h": {
-                "usd": 16.7
-            },
-            "low_24h": {
-                "usd": 14.92
-            },
-            "price_change_24h": -0.9285647810955,
-            "price_change_percentage_24h": -5.65382,
-            "price_change_percentage_7d": 7.31859,
-            "price_change_percentage_14d": 4.26949,
-            "price_change_percentage_30d": -17.80584,
-            "price_change_percentage_60d": -16.87479,
-            "price_change_percentage_200d": 17.7863,
-            "price_change_percentage_1y": -51.86916,
-            "market_cap_change_24h": -470320.4168304,
-            "market_cap_change_percentage_24h": -3.91697,
-            "price_change_24h_in_currency": {
-                "usd": -0.9285647810954956
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -1.75809
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -5.65382
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 7.31859
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 4.26949
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -17.80584
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -16.87479
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 17.7863
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -51.86916
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -470320.4168303814
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -3.91697
-            },
-            "total_supply": 972622.296129312,
-            "max_supply": 972622.296129312,
-            "circulating_supply": 732099.458631534,
-            "last_updated": "2023-06-27T11:50:30.221Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:50:30.221Z"
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 9,
+        "contract_address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "77fba179c79de5b7653f68b5039af940ada60ce0.factory.bridge.near"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 9,
+        "contract_address": "0xf2f5bf00cd952f3f980a02f5dce278cbff4dae05"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 9,
+        "contract_address": "0xdb021b1b247fe2f1fa57e0a87c748cc1e321f07f"
+      },
+      "avalanche": {
+        "decimal_place": 9,
+        "contract_address": "0x027dbca046ca156de9622cd1e2d907d375e53aa7"
+      },
+      "energi": {
+        "decimal_place": 9,
+        "contract_address": "0x79786ed8a70ccec6c7a31debc7fefc5119f9dc95"
+      }
     },
-    {
-        "id": "ribbon-finance",
-        "symbol": "rbn",
-        "name": "Ribbon Finance",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x6123b0049f904d730db3c36a31167d9d4121fa6b"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "Structured Products",
-            "Options",
-            "Decentralized Finance (DeFi)",
-            "Governance"
-        ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Ribbon Finance is a new protocol that helps users access crypto structured products for DeFi. It combines options, futures, and fixed income to improve a portfolio's risk-return profile."
-        },
-        "links": {
-            "homepage": [
-                "https://www.ribbon.finance/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
-                "https://ethplorer.io/address/0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
-                "https://etherscan.io/token/0x6123b0049f904d730db3c36a31167d9d4121fa6b",
-                "https://ethplorer.io/address/0x6123b0049f904d730db3c36a31167d9d4121fa6b",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/85gcVafPyN",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://ribbonfinance.medium.com/",
-                ""
-            ],
-            "twitter_screen_name": "ribbonfinance",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": null,
-            "repos_url": {
-                "github": [
-                    "https://github.com/ribbon-finance"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723",
-            "small": "https://assets.coingecko.com/coins/images/15823/small/RBN_64x64.png?1633529723",
-            "large": "https://assets.coingecko.com/coins/images/15823/large/RBN_64x64.png?1633529723"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b",
-        "sentiment_votes_up_percentage": 100,
-        "sentiment_votes_down_percentage": 0,
-        "watchlist_portfolio_users": 10547,
-        "market_cap_rank": 208,
-        "coingecko_rank": 993,
-        "coingecko_score": 21.527,
-        "developer_score": 0,
-        "community_score": 8.934,
-        "liquidity_score": 27.696,
-        "public_interest_score": 0.006,
-        "market_data": {
-            "current_price": {
-                "usd": 0.180982
-            },
-            "total_value_locked": {
-                "usd": 28041819
-            },
-            "mcap_to_tvl_ratio": 4.71,
-            "fdv_to_tvl_ratio": 6.45,
-            "roi": null,
-            "ath": {
-                "usd": 5.54
-            },
-            "ath_change_percentage": {
-                "usd": -96.73334
-            },
-            "ath_date": {
-                "usd": "2021-10-07T22:30:49.258Z"
-            },
-            "atl": {
-                "usd": 0.12452
-            },
-            "atl_change_percentage": {
-                "usd": 45.38384
-            },
-            "atl_date": {
-                "usd": "2023-05-18T09:35:07.716Z"
-            },
-            "market_cap": {
-                "usd": 131986205
-            },
-            "market_cap_rank": 208,
-            "fully_diluted_valuation": {
-                "usd": 180809094
-            },
-            "total_volume": {
-                "usd": 199626
-            },
-            "high_24h": {
-                "usd": 0.182866
-            },
-            "low_24h": {
-                "usd": 0.180487
-            },
-            "price_change_24h": -0.000829149525859,
-            "price_change_percentage_24h": -0.45605,
-            "price_change_percentage_7d": 0.79798,
-            "price_change_percentage_14d": 14.20085,
-            "price_change_percentage_30d": 12.69548,
-            "price_change_percentage_60d": 15.7171,
-            "price_change_percentage_200d": -22.17242,
-            "price_change_percentage_1y": -29.76689,
-            "market_cap_change_24h": -322524.644935,
-            "market_cap_change_percentage_24h": -0.24377,
-            "price_change_24h_in_currency": {
-                "usd": -0.000829149525859108
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.0598
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.45605
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 0.79798
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 14.20085
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": 12.69548
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": 15.7171
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -22.17242
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -29.76689
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -322524.6449344754
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -0.24377
-            },
-            "total_supply": 1000000000,
-            "max_supply": 1000000000,
-            "circulating_supply": 729975479.254404,
-            "last_updated": "2023-06-27T11:50:29.332Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": null,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:50:29.332Z"
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Harmony Ecosystem",
+      "Ethereum Ecosystem",
+      "Avalanche Ecosystem",
+      "BNB Chain Ecosystem",
+      "Near Protocol Ecosystem",
+      "Rebase Tokens",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Ampleforth is a digital-asset-protocol for smart commodity-money.\r\n\r\nThe smart commodity money with a unique elastic supply protocol. AMPL supply expands and contracts in response to it’s price deviating from a 1 USD target. Deviations result in a supply change of AMPLs once every 24 hours, increasing or decreasing the number of tokens in each holder’s wallet pro-rata. Ampleforth is the only asset in the world with this elastic supply property, and therefore has counter-cyclical trading pressure and is uncorrelated with other digital assets such as Bitcoin."
     },
-    {
-        "id": "rocket-pool",
-        "symbol": "rpl",
-        "name": "Rocket Pool",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-            "arbitrum-one": "0xb766039cc6db368759c1e56b79affe831d0cc507",
-            "polygon-pos": "0x7205705771547cf79201111b4bd8aaf29467b9ec"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f"
-            },
-            "arbitrum-one": {
-                "decimal_place": 18,
-                "contract_address": "0xb766039cc6db368759c1e56b79affe831d0cc507"
-            },
-            "polygon-pos": {
-                "decimal_place": 18,
-                "contract_address": "0x7205705771547cf79201111b4bd8aaf29467b9ec"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Polygon Ecosystem",
-            "Arbitrum Ecosystem",
-            "Liquid Staking Governance Tokens",
-            "Ethereum Ecosystem",
-            "Decentralized Finance (DeFi)",
-            "Business Services",
-            "Infrastructure"
-        ],
-        "public_notice": "Rocket Pool has migrated to a new contract address (0xd33526068d116ce69f19a9ee46f0bd304f21a51f). For more information, please read: https://medium.com/rocket-pool/rocket-pool-rpl-token-upgrade-new-addresses-e96c12c55adf",
-        "additional_notices": [],
-        "description": {
-            "en": "Rocket Pool is Ethereum’s most decentralised liquid staking protocol.\r\nLiquid stakers can participate by depositing as little as 0.01 ETH to receive the rETH liquid staking token.\r\nRocket Pool is a fully non-custodial solution, and its node operators are economically-aligned to perform well for stakers. Joining as a node operator is fully permissionless and requires just 16 ETH (instead of the usual 32). A boosted ROI is provided from both operator commission plus RPL rewards. The Rocket Pool team have been in the staking space since its inception in 2016, which gives them a pedigree and track record without peer."
-        },
-        "links": {
-            "homepage": [
-                "https://www.rocketpool.net",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-                "https://ethplorer.io/address/0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-                "https://arbiscan.io/token/0xB766039cc6DB368759C1E56B79AFfE831d0Cc507",
-                "https://polygonscan.com/token/0x7205705771547cf79201111b4bd8aaf29467b9ec",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discordapp.com/invite/tCRG54c",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://medium.com/rocket-pool",
-                ""
-            ],
-            "twitter_screen_name": "Rocket_Pool",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "",
-            "subreddit_url": "https://www.reddit.com/r/rocketpool",
-            "repos_url": {
-                "github": [
-                    "https://github.com/rocket-pool/rocketpool",
-                    "https://github.com/rocket-pool/smartnode"
-                ],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1637662441",
-            "small": "https://assets.coingecko.com/coins/images/2090/small/rocket_pool_%28RPL%29.png?1637662441",
-            "large": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1637662441"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
-        "sentiment_votes_up_percentage": 80,
-        "sentiment_votes_down_percentage": 20,
-        "ico_data": {
-            "ico_start_date": "2017-11-25T00:00:00.000Z",
-            "ico_end_date": "2018-01-07T00:00:00.000Z",
-            "short_desc": "A decentralised Ethereum Proof of Stake Pool designed to be compatible with Casper.",
-            "description": "Rocket Pool is a next generation pool designed to work with Casper, the new consensus protocol that Ethereum will transition to in 2018. It was the first working implementation of a Proof of Stake pool and features several first to market features; such as load balancing across multiple cloud hosting providers using smart contracts, minipools, widow addresses and deposit tokens. Rocket Pool isn’t just a whitepaper, it’s actual code.",
-            "links": {
-                "web": "https://www.rocketpool.net",
-                "slack": "http://slack.rocketpool.net",
-                "github": "https://github.com/darcius/rocketpool",
-                "medium": "https://medium.com/rocket-pool",
-                "twitter": "https://twitter.com/Rocket_Pool",
-                "linkedin": "https://www.linkedin.com/in/david-rugendyke-260a2a60/",
-                "whitepaper": "https://www.rocketpool.net/files/RocketPoolWhitePaper.pdf"
-            },
-            "softcap_currency": "",
-            "hardcap_currency": "",
-            "total_raised_currency": "",
-            "softcap_amount": null,
-            "hardcap_amount": null,
-            "total_raised": null,
-            "quote_pre_sale_currency": "",
-            "base_pre_sale_amount": null,
-            "quote_pre_sale_amount": null,
-            "quote_public_sale_currency": "",
-            "base_public_sale_amount": 0,
-            "quote_public_sale_amount": 0,
-            "accepting_currencies": "",
-            "country_origin": "",
-            "pre_sale_start_date": null,
-            "pre_sale_end_date": null,
-            "whitelist_url": "",
-            "whitelist_start_date": null,
-            "whitelist_end_date": null,
-            "bounty_detail_url": "",
-            "amount_for_sale": null,
-            "kyc_required": true,
-            "whitelist_available": null,
-            "pre_sale_available": null,
-            "pre_sale_ended": false
-        },
-        "watchlist_portfolio_users": 21289,
-        "market_cap_rank": 61,
-        "coingecko_rank": 92,
-        "coingecko_score": 46.108,
-        "developer_score": 64.98,
-        "community_score": 35.995,
-        "liquidity_score": 34.907,
-        "public_interest_score": 0.005,
-        "market_data": {
-            "current_price": {
-                "usd": 37.95
-            },
-            "total_value_locked": {
-                "usd": 1827961529
-            },
-            "mcap_to_tvl_ratio": 0.4,
-            "fdv_to_tvl_ratio": 0.4,
-            "roi": null,
-            "ath": {
-                "usd": 61.9
-            },
-            "ath_change_percentage": {
-                "usd": -38.94397
-            },
-            "ath_date": {
-                "usd": "2023-04-16T19:20:19.534Z"
-            },
-            "atl": {
-                "usd": 0.00884718
-            },
-            "atl_change_percentage": {
-                "usd": 427069.17964
-            },
-            "atl_date": {
-                "usd": "2018-08-28T00:00:00.000Z"
-            },
-            "market_cap": {
-                "usd": 735980926
-            },
-            "market_cap_rank": 61,
-            "fully_diluted_valuation": {
-                "usd": 735980926
-            },
-            "total_volume": {
-                "usd": 4500024
-            },
-            "high_24h": {
-                "usd": 38.9
-            },
-            "low_24h": {
-                "usd": 37.28
-            },
-            "price_change_24h": -0.3344929901947,
-            "price_change_percentage_24h": -0.87361,
-            "price_change_percentage_7d": -5.59138,
-            "price_change_percentage_14d": -8.39699,
-            "price_change_percentage_30d": -20.6545,
-            "price_change_percentage_60d": -20.67778,
-            "price_change_percentage_200d": 88.70892,
-            "price_change_percentage_1y": 229.12336,
-            "market_cap_change_24h": -9463319.623242,
-            "market_cap_change_percentage_24h": -1.26949,
-            "price_change_24h_in_currency": {
-                "usd": -0.3344929901946898
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.17147
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -0.87361
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": -5.59138
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": -8.39699
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -20.6545
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -20.67778
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": 88.70892
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": 229.12336
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -9463319.623242617
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.26949
-            },
-            "total_supply": 19474470.0383936,
-            "max_supply": null,
-            "circulating_supply": 19474470.0383936,
-            "last_updated": "2023-06-27T11:49:51.641Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 345936,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:49:51.641Z"
+    "links": {
+      "homepage": ["https://www.ampleforth.org/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xd46ba6d942050d489dbd938a2c909a5d5039a161",
+        "https://ethplorer.io/address/0xd46ba6d942050d489dbd938a2c909a5d5039a161",
+        "https://bscscan.com/token/0xdb021b1b247fe2f1fa57e0a87c748cc1e321f07f",
+        "https://cchain.explorer.avax.network/token/0x027dbcA046ca156De9622cD1e2D907d375e53aa7/token-transfers",
+        "https://snowtrace.io/token/0x027dbca046ca156de9622cd1e2d907d375e53aa7",
+        "https://avascan.info/blockchain/c/address/0x027dbca046ca156de9622cd1e2d907d375e53aa7/token",
+        "https://explorer.energi.network/token/0x79786Ed8a70ccEC6C7A31debC7FeFc5119f9dc95",
+        "https://nearblocks.io/token/77fba179c79de5b7653f68b5039af940ada60ce0.factory.bridge.near",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://www.facebook.com/ampleforthprotocol/", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "ampleforthorg",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "Ampleforth",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/ampleforth/uFragments", "https://github.com/ampleforth/market-oracle"],
+        "bitbucket": []
+      }
     },
-    {
-        "id": "shiba-inu",
-        "symbol": "shib",
-        "name": "Shiba Inu",
-        "asset_platform_id": "ethereum",
-        "platforms": {
-            "ethereum": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
-        },
-        "detail_platforms": {
-            "ethereum": {
-                "decimal_place": 18,
-                "contract_address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
-            }
-        },
-        "block_time_in_minutes": 0,
-        "hashing_algorithm": null,
-        "categories": [
-            "Ethereum Ecosystem",
-            "BNB Chain Ecosystem",
-            "Meme"
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/4708/thumb/Ampleforth.png?1561684250",
+      "small": "https://assets.coingecko.com/coins/images/4708/small/Ampleforth.png?1561684250",
+      "large": "https://assets.coingecko.com/coins/images/4708/large/Ampleforth.png?1561684250"
+    },
+    "country_origin": "US",
+    "genesis_date": null,
+    "contract_address": "0xd46ba6d942050d489dbd938a2c909a5d5039a161",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "ico_data": {
+      "ico_start_date": "2019-06-13T13:00:00.000Z",
+      "ico_end_date": "2019-06-19T13:00:00.000Z",
+      "short_desc": "A low volatility cryptocurrency & platform",
+      "description": null,
+      "links": {},
+      "softcap_currency": "",
+      "hardcap_currency": "USD",
+      "total_raised_currency": "",
+      "softcap_amount": null,
+      "hardcap_amount": "4900000.0",
+      "total_raised": null,
+      "quote_pre_sale_currency": "",
+      "base_pre_sale_amount": null,
+      "quote_pre_sale_amount": null,
+      "quote_public_sale_currency": "",
+      "base_public_sale_amount": 0,
+      "quote_public_sale_amount": 0,
+      "accepting_currencies": "",
+      "country_origin": "US",
+      "pre_sale_start_date": null,
+      "pre_sale_end_date": null,
+      "whitelist_url": "",
+      "whitelist_start_date": null,
+      "whitelist_end_date": null,
+      "bounty_detail_url": "",
+      "amount_for_sale": null,
+      "kyc_required": true,
+      "whitelist_available": null,
+      "pre_sale_available": null,
+      "pre_sale_ended": false
+    },
+    "watchlist_portfolio_users": 20249,
+    "market_cap_rank": 524,
+    "coingecko_rank": 290,
+    "coingecko_score": 33.178,
+    "developer_score": 53.613,
+    "community_score": 8.955,
+    "liquidity_score": 23.198,
+    "public_interest_score": 0.004,
+    "market_data": {
+      "current_price": {
+        "usd": 1.36
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 4.07
+      },
+      "ath_change_percentage": {
+        "usd": -66.57167
+      },
+      "ath_date": {
+        "usd": "2020-07-12T20:49:38.893Z"
+      },
+      "atl": {
+        "usd": 0.155869
+      },
+      "atl_change_percentage": {
+        "usd": 772.1245
+      },
+      "atl_date": {
+        "usd": "2019-10-31T23:34:28.705Z"
+      },
+      "market_cap": {
+        "usd": 33295698
+      },
+      "market_cap_rank": 524,
+      "fully_diluted_valuation": {
+        "usd": 40890398
+      },
+      "total_volume": {
+        "usd": 225662
+      },
+      "high_24h": {
+        "usd": 1.37
+      },
+      "low_24h": {
+        "usd": 1.33
+      },
+      "price_change_24h": 0.01021642,
+      "price_change_percentage_24h": 0.75662,
+      "price_change_percentage_7d": 3.01011,
+      "price_change_percentage_14d": 24.49148,
+      "price_change_percentage_30d": 24.64629,
+      "price_change_percentage_60d": 32.97988,
+      "price_change_percentage_200d": 10.51556,
+      "price_change_percentage_1y": 39.16595,
+      "market_cap_change_24h": 703556,
+      "market_cap_change_percentage_24h": 2.15867,
+      "price_change_24h_in_currency": {
+        "usd": 0.01021642
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.53967
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.75662
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 3.01011
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 24.49148
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 24.64629
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 32.97988
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 10.51556
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 39.16595
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 703556
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.15867
+      },
+      "total_supply": 30078434.4121272,
+      "max_supply": null,
+      "circulating_supply": 24491874.15934172,
+      "last_updated": "2023-07-03T17:46:52.014Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 72590,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:52.014Z"
+  },
+  {
+    "id": "ankreth",
+    "symbol": "ankreth",
+    "name": "Ankr Staked ETH",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+      "fantom": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+      "avalanche": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+      "polygon-zkevm": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+      "arbitrum-one": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+      "binance-smart-chain": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c"
+      },
+      "polygon-zkevm": {
+        "decimal_place": 18,
+        "contract_address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "BNB Chain Ecosystem",
+      "Arbitrum Ecosystem",
+      "Avalanche Ecosystem",
+      "Fantom Ecosystem",
+      "Ethereum Ecosystem",
+      "Liquid Staking Tokens",
+      "Eth 2.0 Staking"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "ETH Liquid Staking with Ankr\r\n\r\nAnkr Staking offers Ethereum token holders the opportunity to stake ETH and, in return, claim ETH Liquid Staking tokens — ankrETH. ankrETH also offers instant liquidity for your staked ETH, enabling you to connect ankrETH with DeFi platforms and earn several more layers of rewards.\r\n\r\nankrETH is a reward-bearing token, meaning that the fair value of 1 ankrETH token vs. ETH increases over time as staking rewards accumulate inside the token.\r\n\r\nBenefits\r\n\r\n- Generate Multiple Layers of Rewards: Use ankrETH on DeFi platforms to enable you to multiply your earning potential in APY on top of your staking rewards!\r\n- Low Impermanent Loss: Contributing ankrETH for liquidity with tokens like ETH means a low risk of impermanent loss, expanding the upside of providing liquidity for a more stable and profitable experience.\r\n- Compound Your Staking Rewards: Your staking rewards will compound daily as the value of ankrETH in your wallet increases vs. ETH.\r\n- Support & Secure Ethereum: Staking ETH directly supports the Ethereum network and helps validate transactions. Ankr’s staking system distributes staked tokens intelligently across the Ethereum ecosystem to achieve optimal decentralization.\r\n- Elastic Supply: Users can trade their ankrETH tokens for their staked ETH anytime.\r\n"
+    },
+    "links": {
+      "homepage": ["https://www.ankr.com/about-staking/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+        "https://ethplorer.io/address/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+        "https://ftmscan.com/token/0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+        "https://snowtrace.io/token/0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+        "https://avascan.info/blockchain/c/address/0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c/token",
+        "https://zkevm.polygonscan.com/token/0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+        "https://arbiscan.io/token/0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+        "https://bscscan.com/token/0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": [
+        "https://discord.com/invite/ankr",
+        "https://medium.com/ankr-network",
+        "https://youtube.com/@AnkrOfficial"
+      ],
+      "announcement_url": ["https://medium.com/ankr-network", ""],
+      "twitter_screen_name": "ankr",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "ankrnetwork",
+      "subreddit_url": "https://www.reddit.com/r/Ankrofficial",
+      "repos_url": {
+        "github": ["https://github.com/Ankr-network/stkr-smartcontract-public"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/13403/thumb/aETHc.png?1625756490",
+      "small": "https://assets.coingecko.com/coins/images/13403/small/aETHc.png?1625756490",
+      "large": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1625756490"
+    },
+    "country_origin": "US",
+    "genesis_date": null,
+    "contract_address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 1081,
+    "market_cap_rank": 274,
+    "coingecko_rank": 1802,
+    "coingecko_score": 16,
+    "developer_score": 0,
+    "community_score": 10.378,
+    "liquidity_score": 1,
+    "public_interest_score": 0.004,
+    "market_data": {
+      "current_price": {
+        "usd": 2203.24
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 4733.13
+      },
+      "ath_change_percentage": {
+        "usd": -53.44769
+      },
+      "ath_date": {
+        "usd": "2021-11-26T04:33:49.980Z"
+      },
+      "atl": {
+        "usd": 534.32
+      },
+      "atl_change_percentage": {
+        "usd": 312.37419
+      },
+      "atl_date": {
+        "usd": "2020-12-24T06:45:06.825Z"
+      },
+      "market_cap": {
+        "usd": 93529677
+      },
+      "market_cap_rank": 274,
+      "fully_diluted_valuation": {
+        "usd": 93529677
+      },
+      "total_volume": {
+        "usd": 15810.18
+      },
+      "high_24h": {
+        "usd": 2207.36
+      },
+      "low_24h": {
+        "usd": 2138.36
+      },
+      "price_change_24h": 61.09,
+      "price_change_percentage_24h": 2.85199,
+      "price_change_percentage_7d": 5.93122,
+      "price_change_percentage_14d": 14.92025,
+      "price_change_percentage_30d": 4.56592,
+      "price_change_percentage_60d": 5.89873,
+      "price_change_percentage_200d": 78.593,
+      "price_change_percentage_1y": 127.02788,
+      "market_cap_change_24h": 2551392,
+      "market_cap_change_percentage_24h": 2.8044,
+      "price_change_24h_in_currency": {
+        "usd": 61.09
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.31367
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.85199
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 5.93122
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 14.92025
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 4.56592
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 5.89873
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 78.593
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 127.02788
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 2551392
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.8044
+      },
+      "total_supply": 42469.3434714766,
+      "max_supply": null,
+      "circulating_supply": 42469.3434714766,
+      "last_updated": "2023-07-03T17:46:46.237Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:46.237Z"
+  },
+  {
+    "id": "arbitrum",
+    "symbol": "arb",
+    "name": "Arbitrum",
+    "asset_platform_id": "arbitrum-one",
+    "platforms": {
+      "arbitrum-one": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "arbitrum-nova": "0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad",
+      "ethereum": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1"
+    },
+    "detail_platforms": {
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x912ce59144191c1204e64559fe8253a0e49e6548"
+      },
+      "arbitrum-nova": {
+        "decimal_place": 18,
+        "contract_address": "0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad"
+      },
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Arbitrum Nova Ecosystem", "Ethereum Ecosystem", "Arbitrum Ecosystem", "Layer 2 (L2)"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Arbitrum is one of the leading Ethereum scaling solutions bringing cheap transactions to tens of thousands of users in an environment that feels very similar to Ethereum. It is an optimistic rollup and the leading L2 in terms of TVL. Some of the largest dApps live on Arbitrum include GMX, Radiant, Uniswap V3, and Gains Network."
+    },
+    "links": {
+      "homepage": ["https://arbitrum.io/", "http://arbitrum.foundation", ""],
+      "blockchain_site": [
+        "https://arbiscan.io/token/0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "https://etherscan.io/token/0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
+        "https://ethplorer.io/address/0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
+        "https://nova.arbiscan.io/token/0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad",
+        "https://www.oklink.com/arbitrum",
+        "https://3xpl.com/arbitrum-one",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/Arbitrum", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "arbitrum",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/ArbitrumFoundation"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/16547/thumb/photo_2023-03-29_21.47.00.jpeg?1680097630",
+      "small": "https://assets.coingecko.com/coins/images/16547/small/photo_2023-03-29_21.47.00.jpeg?1680097630",
+      "large": "https://assets.coingecko.com/coins/images/16547/large/photo_2023-03-29_21.47.00.jpeg?1680097630"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+    "sentiment_votes_up_percentage": 85.88,
+    "sentiment_votes_down_percentage": 14.12,
+    "watchlist_portfolio_users": 78020,
+    "market_cap_rank": 37,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 1.17
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 8.67
+      },
+      "ath_change_percentage": {
+        "usd": -86.48564
+      },
+      "ath_date": {
+        "usd": "2023-03-23T13:10:03.106Z"
+      },
+      "atl": {
+        "usd": 0.912886
+      },
+      "atl_change_percentage": {
+        "usd": 28.39897
+      },
+      "atl_date": {
+        "usd": "2023-06-15T07:25:14.752Z"
+      },
+      "market_cap": {
+        "usd": 1495123016
+      },
+      "market_cap_rank": 37,
+      "fully_diluted_valuation": {
+        "usd": 11726455029
+      },
+      "total_volume": {
+        "usd": 168269868
+      },
+      "high_24h": {
+        "usd": 1.18
+      },
+      "low_24h": {
+        "usd": 1.13
+      },
+      "price_change_24h": 0.03770144,
+      "price_change_percentage_24h": 3.3267,
+      "price_change_percentage_7d": 3.57758,
+      "price_change_percentage_14d": 17.52979,
+      "price_change_percentage_30d": -5.18246,
+      "price_change_percentage_60d": -11.99704,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": 48022408,
+      "market_cap_change_percentage_24h": 3.31853,
+      "price_change_24h_in_currency": {
+        "usd": 0.03770144
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.13062
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 3.3267
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 3.57758
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 17.52979
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -5.18246
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -11.99704
+      },
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {
+        "usd": 48022408
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 3.31853
+      },
+      "total_supply": 10000000000,
+      "max_supply": 10000000000,
+      "circulating_supply": 1275000000,
+      "last_updated": "2023-07-03T17:46:29.183Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:46:29.183Z"
+  },
+  {
+    "id": "aura-bal",
+    "symbol": "aurabal",
+    "name": "Aura BAL",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Decentralized Finance (DeFi)", "Ethereum Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "auraBAL is a liquid wrapper for Balancer's veBAL. Aura allows users to deposit their 80/20 BAL/WETH BPT and receive liquid auraBAL, instead of the non-transferrable veBAL. Tokenised auraBAL is given to the user at a 1:1 rate for veBAL, and can be traded on Balancer or elsewhere.\r\n\r\nThis BPT is then locked up by the Aura protocol for the maximum time in Balancer Voting Escrow where it will allow the Aura system to benefit from its voting power for boosting rewards & voting for gauges."
+    },
+    "links": {
+      "homepage": ["https://aura.finance/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
+        "https://ethplorer.io/address/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["https://mirror.xyz/0xfEE0Bbe31345a7c27368534fEf45a57133FF3A86", "", ""],
+      "chat_url": ["https://discord.gg/aurafinance", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "AuraFinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "aurafinance",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/aurafinance"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/26538/thumb/auraBAL.png?1658721102",
+      "small": "https://assets.coingecko.com/coins/images/26538/small/auraBAL.png?1658721102",
+      "large": "https://assets.coingecko.com/coins/images/26538/large/auraBAL.png?1658721102"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 268,
+    "market_cap_rank": 456,
+    "coingecko_rank": 5858,
+    "coingecko_score": 1.912,
+    "developer_score": 0,
+    "community_score": 7.78,
+    "liquidity_score": 1,
+    "public_interest_score": 0.003,
+    "market_data": {
+      "current_price": {
+        "usd": 13.68
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 21.61
+      },
+      "ath_change_percentage": {
+        "usd": -36.6609
+      },
+      "ath_date": {
+        "usd": "2023-01-31T20:55:03.507Z"
+      },
+      "atl": {
+        "usd": 8.2
+      },
+      "atl_change_percentage": {
+        "usd": 66.96307
+      },
+      "atl_date": {
+        "usd": "2022-11-09T13:15:21.224Z"
+      },
+      "market_cap": {
+        "usd": 42742409
+      },
+      "market_cap_rank": 456,
+      "fully_diluted_valuation": {
+        "usd": 42742409
+      },
+      "total_volume": {
+        "usd": 41997
+      },
+      "high_24h": {
+        "usd": 13.75
+      },
+      "low_24h": {
+        "usd": 13.19
+      },
+      "price_change_24h": 0.364972,
+      "price_change_percentage_24h": 2.74121,
+      "price_change_percentage_7d": 6.37206,
+      "price_change_percentage_14d": 10.35966,
+      "price_change_percentage_30d": -5.30067,
+      "price_change_percentage_60d": -6.50731,
+      "price_change_percentage_200d": 1.19663,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": 1230442,
+      "market_cap_change_percentage_24h": 2.96407,
+      "price_change_24h_in_currency": {
+        "usd": 0.364972
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.2311
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.74121
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 6.37206
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 10.35966
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -5.30067
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -6.50731
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 1.19663
+      },
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {
+        "usd": 1230442
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.96407
+      },
+      "total_supply": 3121833.59676527,
+      "max_supply": null,
+      "circulating_supply": 3121833.59676527,
+      "last_updated": "2023-07-03T17:47:40.104Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:47:40.104Z"
+  },
+  {
+    "id": "aura-finance",
+    "symbol": "aura",
+    "name": "Aura Finance",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Decentralized Finance (DeFi)", "Metagovernance", "Ethereum Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Centered around Balancer’s veBAL, Aura coordinates incentives around vote-escrowed tokens to boost yield potential and governance power of DeFi liquidity providers, governance token stakers and voters."
+    },
+    "links": {
+      "homepage": ["https://aura.finance", "https://app.aura.finance", "https://docs.aura.finance"],
+      "blockchain_site": [
+        "https://etherscan.io/address/0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+        "https://etherscan.io/token/0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF",
+        "https://ethplorer.io/address/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["https://mirror.xyz/0xfEE0Bbe31345a7c27368534fEf45a57133FF3A86", "", ""],
+      "chat_url": ["https://discord.gg/aurafinance", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "aurafinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "aurafinance",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/aurafinance/"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/25942/thumb/logo.png?1654784187",
+      "small": "https://assets.coingecko.com/coins/images/25942/small/logo.png?1654784187",
+      "large": "https://assets.coingecko.com/coins/images/25942/large/logo.png?1654784187"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 6430,
+    "market_cap_rank": 398,
+    "coingecko_rank": 1576,
+    "coingecko_score": 17.272,
+    "developer_score": 0,
+    "community_score": 7.78,
+    "liquidity_score": 13.758,
+    "public_interest_score": 0.003,
+    "market_data": {
+      "current_price": {
+        "usd": 1.84
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 4.05
+      },
+      "ath_change_percentage": {
+        "usd": -54.47473
+      },
+      "ath_date": {
+        "usd": "2023-03-14T13:19:41.812Z"
+      },
+      "atl": {
+        "usd": 0.445907
+      },
+      "atl_change_percentage": {
+        "usd": 313.09405
+      },
+      "atl_date": {
+        "usd": "2022-06-17T07:20:33.005Z"
+      },
+      "market_cap": {
+        "usd": 52329151
+      },
+      "market_cap_rank": 398,
+      "fully_diluted_valuation": {
+        "usd": 184383044
+      },
+      "total_volume": {
+        "usd": 906776
+      },
+      "high_24h": {
+        "usd": 1.89
+      },
+      "low_24h": {
+        "usd": 1.76
+      },
+      "price_change_24h": 0.074126,
+      "price_change_percentage_24h": 4.1956,
+      "price_change_percentage_7d": 8.43189,
+      "price_change_percentage_14d": 16.78371,
+      "price_change_percentage_30d": -0.33466,
+      "price_change_percentage_60d": -17.07282,
+      "price_change_percentage_200d": -10.58315,
+      "price_change_percentage_1y": 39.46522,
+      "market_cap_change_24h": 2125557,
+      "market_cap_change_percentage_24h": 4.23387,
+      "price_change_24h_in_currency": {
+        "usd": 0.074126
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.21563
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 4.1956
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 8.43189
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 16.78371
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -0.33466
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -17.07282
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -10.58315
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 39.46522
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 2125557
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.23387
+      },
+      "total_supply": 62732494.595434,
+      "max_supply": 100000000,
+      "circulating_supply": 28380674.4008115,
+      "last_updated": "2023-07-03T17:48:45.930Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:48:45.930Z"
+  },
+  {
+    "id": "badger-dao",
+    "symbol": "badger",
+    "name": "Badger DAO",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+      "xdai": "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65",
+      "fantom": "0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
+      "harmony-shard-0": "0x06b19a0ce12dc71f1c7a6dd39e8983e089c40e0d",
+      "arbitrum-one": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
+      "energi": "0x32e6842a6ea6a913687885ac856c2493b5b12f6f"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x3472a5a71965499acd81997a54bba8d852c6e53d"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0xdfc20ae04ed70bd9c7d720f449eedae19f659d65"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0x06b19a0ce12dc71f1c7a6dd39e8983e089c40e0d"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0x32e6842a6ea6a913687885ac856c2493b5b12f6f"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Ethereum Ecosystem",
+      "Fantom Ecosystem",
+      "Arbitrum Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Polygon Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "Governance",
+      "Yield Farming",
+      "Yield Aggregator"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Badger DAO aims to create an ecosystem of DeFi products with the ultimate goal of bringing Bitcoin into Ethereum. It is the first DeFi project that chose to focus on BTC as the main reserve asset rather than using ETH. \r\n\r\nDuring launch, there are two main products, Sett and DIGG. "
+    },
+    "links": {
+      "homepage": ["https://app.badger.finance/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x3472a5a71965499acd81997a54bba8d852c6e53d",
+        "https://ethplorer.io/address/0x3472a5a71965499acd81997a54bba8d852c6e53d",
+        "https://blockscout.com/poa/xdai/tokens/0xdfc20AE04ED70bd9c7D720F449eEDAe19F659D65/token-transfers",
+        "https://arbiscan.io/token/0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
+        "https://ftmscan.com/token/0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
+        "https://scan.meter.io/address/0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
+        "https://ftmscan.com/address/0x753fbc5800a8c8e3fb6dc6415810d627a387dfc9",
+        "https://explorer.energi.network/token/0x32e6842a6ea6a913687885ac856c2493b5b12f6f",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/badgerdao", "", ""],
+      "announcement_url": ["https://badgerdao.medium.com/", ""],
+      "twitter_screen_name": "badgerdao",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "badger_dao",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/Badger-Finance", "https://github.com/Badger-Finance/badger-system"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976",
+      "small": "https://assets.coingecko.com/coins/images/13287/small/badger_dao_logo.jpg?1607054976",
+      "large": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1607054976"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+    "sentiment_votes_up_percentage": 0,
+    "sentiment_votes_down_percentage": 100,
+    "watchlist_portfolio_users": 22732,
+    "market_cap_rank": 445,
+    "coingecko_rank": 804,
+    "coingecko_score": 23.207,
+    "developer_score": 0,
+    "community_score": 9.094,
+    "liquidity_score": 38.848,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 2.25
+      },
+      "total_value_locked": {
+        "usd": 36234033
+      },
+      "mcap_to_tvl_ratio": 1.22,
+      "fdv_to_tvl_ratio": 1.3,
+      "roi": null,
+      "ath": {
+        "usd": 89.08
+      },
+      "ath_change_percentage": {
+        "usd": -97.47412
+      },
+      "ath_date": {
+        "usd": "2021-02-09T01:03:21.398Z"
+      },
+      "atl": {
+        "usd": 1.83
+      },
+      "atl_change_percentage": {
+        "usd": 22.70915
+      },
+      "atl_date": {
+        "usd": "2023-06-10T04:30:39.245Z"
+      },
+      "market_cap": {
+        "usd": 44039397
+      },
+      "market_cap_rank": 445,
+      "fully_diluted_valuation": {
+        "usd": 47004454
+      },
+      "total_volume": {
+        "usd": 1543069
+      },
+      "high_24h": {
+        "usd": 2.27
+      },
+      "low_24h": {
+        "usd": 2.18
+      },
+      "price_change_24h": 0.051609,
+      "price_change_percentage_24h": 2.3494,
+      "price_change_percentage_7d": 0.01578,
+      "price_change_percentage_14d": 9.6392,
+      "price_change_percentage_30d": -7.40971,
+      "price_change_percentage_60d": -18.79277,
+      "price_change_percentage_200d": -10.23596,
+      "price_change_percentage_1y": -25.44609,
+      "market_cap_change_24h": 781963,
+      "market_cap_change_percentage_24h": 1.8077,
+      "price_change_24h_in_currency": {
+        "usd": 0.051609
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.7561
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.3494
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 0.01578
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 9.6392
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -7.40971
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -18.79277
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -10.23596
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -25.44609
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 781963
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 1.8077
+      },
+      "total_supply": 21000000,
+      "max_supply": 21000000,
+      "circulating_supply": 19675312.83332277,
+      "last_updated": "2023-07-03T17:48:52.315Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:48:52.315Z"
+  },
+  {
+    "id": "balancer",
+    "symbol": "bal",
+    "name": "Balancer",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xba100000625a3754423978a60c9317c58a424e3d",
+      "near-protocol": "ba100000625a3754423978a60c9317c58a424e3d.factory.bridge.near",
+      "xdai": "0x7ef541e2a22058048904fe5744f9c7e4c57af717",
+      "polygon-zkevm": "0x120ef59b80774f02211563834d8e3b72cb1649d6",
+      "avalanche": "0x8239a6b877804206c7799028232a7188da487cec",
+      "huobi-token": "0x045de15ca76e76426e8fc7cba8392a3138078d0f",
+      "polygon-pos": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+      "harmony-shard-0": "0xdc5f76104d0b8d2bf2c2bbe06cdfe17004e9010f",
+      "arbitrum-one": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+      "energi": "0x9b817c6e9a38e604606aea3ad6ed271ce8eaa9d6",
+      "optimistic-ethereum": "0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xba100000625a3754423978a60c9317c58a424e3d"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "ba100000625a3754423978a60c9317c58a424e3d.factory.bridge.near"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0x7ef541e2a22058048904fe5744f9c7e4c57af717"
+      },
+      "polygon-zkevm": {
+        "decimal_place": 18,
+        "contract_address": "0x120ef59b80774f02211563834d8e3b72cb1649d6"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x8239a6b877804206c7799028232a7188da487cec"
+      },
+      "huobi-token": {
+        "decimal_place": 18,
+        "contract_address": "0x045de15ca76e76426e8fc7cba8392a3138078d0f"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0xdc5f76104d0b8d2bf2c2bbe06cdfe17004e9010f"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0x9b817c6e9a38e604606aea3ad6ed271ce8eaa9d6"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Avalanche Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Optimism Ecosystem",
+      "Harmony Ecosystem",
+      "Ethereum Ecosystem",
+      "Arbitrum Ecosystem",
+      "Polygon Ecosystem",
+      "Near Protocol Ecosystem",
+      "Automated Market Maker (AMM)",
+      "Yield Farming",
+      "Governance",
+      "Exchange-based Tokens",
+      "Decentralized Finance (DeFi)",
+      "Decentralized Exchange (DEX)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Balancer is a non-custodial portfolio manager, liquidity provider, and price sensor\r\n\r\nThe Balancer Protocol Governance Token (BAL) are distributed to Liquidity Providers of Balancer. BALs are a key way of decentralizing the governance of the protocol such that it can remain resilient over time, protected from the failure of any single stakeholder. \r\n\r\nThe proposed amount of distributed BALs to liquidity providers is 145,000 per week, or approximately 7.5M per year. This means in the first year of BAL’s existence there would be 30% supply inflation off the initially allocated supply of 25M tokens. This high rate of supply inflation is meant to kickstart the distribution of governance rights of the protocol out to those who earn it."
+    },
+    "links": {
+      "homepage": ["https://balancer.finance/", "http://balancer.exchange/", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xba100000625a3754423978a60c9317c58a424e3D",
+        "https://ethplorer.io/address/0xba100000625a3754423978a60c9317c58a424e3d",
+        "https://arbiscan.io/token/0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+        "https://polygonscan.com/token/0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "https://explorer.energi.network/token/0x9b817c6e9a38e604606aea3ad6ed271ce8eaa9d6",
+        "https://optimistic.etherscan.io/token/0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921",
+        "https://nearblocks.io/token/ba100000625a3754423978a60c9317c58a424e3d.factory.bridge.near",
+        "https://blockscout.com/xdai/mainnet/token/0x7eF541E2a22058048904fE5744f9c7E4C57AF717/token-transfers",
+        "https://zkevm.polygonscan.com/token/0x120eF59b80774F02211563834d8E3b72cb1649d6",
+        "https://snowtrace.io/token/0x8239a6b877804206c7799028232a7188da487cec"
+      ],
+      "official_forum_url": ["https://forum.balancer.finance/", "", ""],
+      "chat_url": ["https://discord.gg/ARJWaeF", "", ""],
+      "announcement_url": ["https://balancer.finance/blog-feed/", "https://medium.com/balancer-protocol"],
+      "twitter_screen_name": "Balancer",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [
+          "https://github.com/balancer-labs/balancer-core",
+          "https://github.com/balancer-labs/balancer-exchange",
+          "https://github.com/balancer-labs/pool-management",
+          "https://github.com/balancer-labs/balancer-sor"
         ],
-        "public_notice": null,
-        "additional_notices": [],
-        "description": {
-            "en": "Shiba Inu (SHIB) is a meme token which began as a fun currency and has now transformed into a decentralized ecosystem. During the initial launch, 50% of the supply was allocated into Vitalik Buterin's ethereum wallet. \r\n\r\nAs a result of that, Vitalik proceeded to donate 10% of his SHIB holdings to a COVID-19 relief effort in India and the remaining 40% is burnt forever. That donation was worth about $1 billion at that time, which makes it one of the largest donation ever in the world.\r\n\r\nWhat is the Shiba Inu community working on right now? The Shiba Inu team launched a decentralized exchange called Shibaswap with 2 new tokens, LEASH and BONE. LEASH is a scarce supply token that is used to offer incentives on Shibaswap. BONE is the governance token for holders to vote on proposals on Doggy DAO."
-        },
-        "links": {
-            "homepage": [
-                "https://shibatoken.com/",
-                "",
-                ""
-            ],
-            "blockchain_site": [
-                "https://etherscan.io/token/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
-                "https://ethplorer.io/address/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
-                "https://bscscan.com/token/0x2859e4544c4bb03966803b044a93563bd2d0dd4d",
-                "https://explorer.energi.network/token/0x7fDb933327aa6989ae706001c2EA54BA5E046e79",
-                "",
-                "",
-                "",
-                "",
-                "",
-                ""
-            ],
-            "official_forum_url": [
-                "",
-                "",
-                ""
-            ],
-            "chat_url": [
-                "https://discord.com/invite/shibatoken",
-                "",
-                ""
-            ],
-            "announcement_url": [
-                "https://blog.shibaswap.com/",
-                ""
-            ],
-            "twitter_screen_name": "Shibtoken",
-            "facebook_username": "",
-            "bitcointalk_thread_identifier": null,
-            "telegram_channel_identifier": "ShibaInu_Dogecoinkiller",
-            "subreddit_url": "https://www.reddit.com/r/SHIBArmy/",
-            "repos_url": {
-                "github": [],
-                "bitbucket": []
-            }
-        },
-        "image": {
-            "thumb": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
-            "small": "https://assets.coingecko.com/coins/images/11939/small/shiba.png?1622619446",
-            "large": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1622619446"
-        },
-        "country_origin": "",
-        "genesis_date": null,
-        "contract_address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
-        "sentiment_votes_up_percentage": 62.9,
-        "sentiment_votes_down_percentage": 37.1,
-        "watchlist_portfolio_users": 595125,
-        "market_cap_rank": 18,
-        "coingecko_rank": 132,
-        "coingecko_score": 42.68,
-        "developer_score": 0,
-        "community_score": 56.215,
-        "liquidity_score": 66.79,
-        "public_interest_score": 0.01,
-        "market_data": {
-            "current_price": {
-                "usd": 0.00000761
-            },
-            "total_value_locked": null,
-            "mcap_to_tvl_ratio": null,
-            "fdv_to_tvl_ratio": null,
-            "roi": null,
-            "ath": {
-                "usd": 0.00008616
-            },
-            "ath_change_percentage": {
-                "usd": -91.17664
-            },
-            "ath_date": {
-                "usd": "2021-10-28T03:54:55.568Z"
-            },
-            "atl": {
-                "usd": 5.6366e-11
-            },
-            "atl_change_percentage": {
-                "usd": 13486846.90324
-            },
-            "atl_date": {
-                "usd": "2020-11-28T11:26:25.838Z"
-            },
-            "market_cap": {
-                "usd": 4487084981
-            },
-            "market_cap_rank": 18,
-            "fully_diluted_valuation": {
-                "usd": 7613671305
-            },
-            "total_volume": {
-                "usd": 94565917
-            },
-            "high_24h": {
-                "usd": 0.00000782
-            },
-            "low_24h": {
-                "usd": 0.00000747
-            },
-            "price_change_24h": -1.17696221718e-7,
-            "price_change_percentage_24h": -1.5223,
-            "price_change_percentage_7d": 6.31066,
-            "price_change_percentage_14d": 12.46013,
-            "price_change_percentage_30d": -13.79037,
-            "price_change_percentage_60d": -26.03103,
-            "price_change_percentage_200d": -18.30178,
-            "price_change_percentage_1y": -34.11595,
-            "market_cap_change_24h": -72953389.74407,
-            "market_cap_change_percentage_24h": -1.59984,
-            "price_change_24h_in_currency": {
-                "usd": -1.17696221718e-7
-            },
-            "price_change_percentage_1h_in_currency": {
-                "usd": -0.04326
-            },
-            "price_change_percentage_24h_in_currency": {
-                "usd": -1.5223
-            },
-            "price_change_percentage_7d_in_currency": {
-                "usd": 6.31066
-            },
-            "price_change_percentage_14d_in_currency": {
-                "usd": 12.46013
-            },
-            "price_change_percentage_30d_in_currency": {
-                "usd": -13.79037
-            },
-            "price_change_percentage_60d_in_currency": {
-                "usd": -26.03103
-            },
-            "price_change_percentage_200d_in_currency": {
-                "usd": -18.30178
-            },
-            "price_change_percentage_1y_in_currency": {
-                "usd": -34.11595
-            },
-            "market_cap_change_24h_in_currency": {
-                "usd": -72953389.74407196
-            },
-            "market_cap_change_percentage_24h_in_currency": {
-                "usd": -1.59984
-            },
-            "total_supply": 999988946554728,
-            "max_supply": null,
-            "circulating_supply": 589339256164948.4,
-            "last_updated": "2023-06-27T11:50:41.419Z"
-        },
-        "public_interest_stats": {
-            "alexa_rank": 4476531,
-            "bing_matches": null
-        },
-        "status_updates": [],
-        "last_updated": "2023-06-27T11:50:41.419Z"
-    }
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/11683/thumb/Balancer.png?1592792958",
+      "small": "https://assets.coingecko.com/coins/images/11683/small/Balancer.png?1592792958",
+      "large": "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1592792958"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xba100000625a3754423978a60c9317c58a424e3d",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 33706,
+    "market_cap_rank": 164,
+    "coingecko_rank": 166,
+    "coingecko_score": 39.975,
+    "developer_score": 60.667,
+    "community_score": 7.225,
+    "liquidity_score": 44.45,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 4.95
+      },
+      "total_value_locked": {
+        "usd": 1099872780
+      },
+      "mcap_to_tvl_ratio": 0.19,
+      "fdv_to_tvl_ratio": 0.43,
+      "roi": null,
+      "ath": {
+        "usd": 74.45
+      },
+      "ath_change_percentage": {
+        "usd": -93.35209
+      },
+      "ath_date": {
+        "usd": "2021-05-04T13:35:02.939Z"
+      },
+      "atl": {
+        "usd": 3.66
+      },
+      "atl_change_percentage": {
+        "usd": 35.38659
+      },
+      "atl_date": {
+        "usd": "2022-06-18T21:00:00.231Z"
+      },
+      "market_cap": {
+        "usd": 207381225
+      },
+      "market_cap_rank": 164,
+      "fully_diluted_valuation": {
+        "usd": 475988101
+      },
+      "total_volume": {
+        "usd": 3431139
+      },
+      "high_24h": {
+        "usd": 4.97
+      },
+      "low_24h": {
+        "usd": 4.78
+      },
+      "price_change_24h": 0.144031,
+      "price_change_percentage_24h": 2.99889,
+      "price_change_percentage_7d": 5.70293,
+      "price_change_percentage_14d": 13.37523,
+      "price_change_percentage_30d": -6.79402,
+      "price_change_percentage_60d": -18.66006,
+      "price_change_percentage_200d": -18.12677,
+      "price_change_percentage_1y": 8.90516,
+      "market_cap_change_24h": 5655543,
+      "market_cap_change_percentage_24h": 2.80358,
+      "price_change_24h_in_currency": {
+        "usd": 0.144031
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.94504
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.99889
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 5.70293
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 13.37523
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -6.79402
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -18.66006
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -18.12677
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 8.90516
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 5655543
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.80358
+      },
+      "total_supply": 57862209.552517,
+      "max_supply": 96150704,
+      "circulating_supply": 41891490.068855,
+      "last_updated": "2023-07-03T17:48:22.220Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 64391,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:48:22.220Z"
+  },
+  {
+    "id": "chainlink",
+    "symbol": "link",
+    "name": "Chainlink",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x514910771af9ca656af840dff83e8264ecf986ca",
+      "near-protocol": "514910771af9ca656af840dff83e8264ecf986ca.factory.bridge.near",
+      "xdai": "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2",
+      "binance-smart-chain": "0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd",
+      "polygon-pos": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+      "huobi-token": "0x9e004545c59d359f6b7bfb06a26390b087717b42",
+      "optimistic-ethereum": "0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6",
+      "harmony-shard-0": "0x218532a12a389a4a92fc0c5fb22901d1c19198aa",
+      "avalanche": "0x5947bb275c521040051d82396192181b413227a3",
+      "arbitrum-one": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+      "sora": "0x008484148dcf23d1b48908393e7a00d5fdc3bf81029a73eeca62a15ebfb1205a",
+      "fantom": "0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8",
+      "milkomeda-cardano": "0xf390830df829cf22c53c8840554b98eafc5dcbc2",
+      "energi": "0x68ca48ca2626c415a89756471d4ade2cc9034008",
+      "osmosis": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x514910771af9ca656af840dff83e8264ecf986ca"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "514910771af9ca656af840dff83e8264ecf986ca.factory.bridge.near"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39"
+      },
+      "huobi-token": {
+        "decimal_place": 18,
+        "contract_address": "0x9e004545c59d359f6b7bfb06a26390b087717b42"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0x218532a12a389a4a92fc0c5fb22901d1c19198aa"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x5947bb275c521040051d82396192181b413227a3"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4"
+      },
+      "sora": {
+        "decimal_place": 18,
+        "contract_address": "0x008484148dcf23d1b48908393e7a00d5fdc3bf81029a73eeca62a15ebfb1205a"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8"
+      },
+      "milkomeda-cardano": {
+        "decimal_place": 18,
+        "contract_address": "0xf390830df829cf22c53c8840554b98eafc5dcbc2"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0x68ca48ca2626c415a89756471d4ade2cc9034008"
+      },
+      "osmosis": {
+        "decimal_place": null,
+        "contract_address": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Harmony Ecosystem",
+      "Optimism Ecosystem",
+      "Ethereum Ecosystem",
+      "Edgeware Ecosystem",
+      "Fantom Ecosystem",
+      "Arbitrum Ecosystem",
+      "Avalanche Ecosystem",
+      "BNB Chain Ecosystem",
+      "Cardano Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Polygon Ecosystem",
+      "Near Protocol Ecosystem",
+      "Solana Ecosystem",
+      "Infrastructure",
+      "Polkadot Ecosystem",
+      "Oracle",
+      "Decentralized Finance (DeFi)",
+      "Business Services",
+      "Smart Contract Platform"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Chainlink is a framework for building Decentralized Oracle Networks (DONs) that bring real-world data onto blockchain networks, enabling the creation of hybrid smart contracts. These DONs provide decentralized services such as Price Feeds, Proof of Reserve, Verifiable Randomness, Keepers, and the ability to connect to any web API. \r\n\r\nIt aims to ensure that the external information (pricing, weather data, event outcomes, etc.) and off-chain computations (randomness, transaction automation, fair ordering, etc.) fed to on-chain smart contracts are reliable and tamper-proof."
+    },
+    "links": {
+      "homepage": ["https://chain.link/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x514910771af9ca656af840dff83e8264ecf986ca",
+        "https://ethplorer.io/address/0x514910771af9ca656af840dff83e8264ecf986ca",
+        "https://arbiscan.io/token/0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+        "https://explorer.chain.link",
+        "https://blockscout.com/poa/xdai/tokens/0xE2e73A1c69ecF83F464EFCE6A5be353a37cA09b2/token-transfers",
+        "https://bscscan.com/token/0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd",
+        "https://polygonscan.com/token/0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "https://snowtrace.io/token/0x5947bb275c521040051d82396192181b413227a3",
+        "https://nearblocks.io/token/514910771af9ca656af840dff83e8264ecf986ca.factory.bridge.near",
+        "https://scan.meter.io/address/0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8"
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "", ""],
+      "announcement_url": ["https://blog.chain.link/", ""],
+      "twitter_screen_name": "chainlink",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "chainlinkofficial",
+      "subreddit_url": "https://www.reddit.com/r/Chainlink/",
+      "repos_url": {
+        "github": [
+          "https://github.com/smartcontractkit/chainlink",
+          "https://github.com/smartcontractkit/chainlink-ruby"
+        ],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/877/thumb/chainlink-new-logo.png?1547034700",
+      "small": "https://assets.coingecko.com/coins/images/877/small/chainlink-new-logo.png?1547034700",
+      "large": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1547034700"
+    },
+    "country_origin": "",
+    "genesis_date": "2017-09-16",
+    "contract_address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+    "sentiment_votes_up_percentage": 81.82,
+    "sentiment_votes_down_percentage": 18.18,
+    "watchlist_portfolio_users": 381162,
+    "market_cap_rank": 23,
+    "coingecko_rank": 8,
+    "coingecko_score": 62.148,
+    "developer_score": 85.761,
+    "community_score": 45.578,
+    "liquidity_score": 70.956,
+    "public_interest_score": 0.047,
+    "market_data": {
+      "current_price": {
+        "usd": 6.61
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 52.7
+      },
+      "ath_change_percentage": {
+        "usd": -87.43627
+      },
+      "ath_date": {
+        "usd": "2021-05-10T00:13:57.214Z"
+      },
+      "atl": {
+        "usd": 0.148183
+      },
+      "atl_change_percentage": {
+        "usd": 4367.88742
+      },
+      "atl_date": {
+        "usd": "2017-11-29T00:00:00.000Z"
+      },
+      "market_cap": {
+        "usd": 3423528599
+      },
+      "market_cap_rank": 23,
+      "fully_diluted_valuation": {
+        "usd": 6620631953
+      },
+      "total_volume": {
+        "usd": 192664313
+      },
+      "high_24h": {
+        "usd": 6.65
+      },
+      "low_24h": {
+        "usd": 6.38
+      },
+      "price_change_24h": 0.20682976,
+      "price_change_percentage_24h": 3.2299,
+      "price_change_percentage_7d": 8.20861,
+      "price_change_percentage_14d": 31.63034,
+      "price_change_percentage_30d": 2.74172,
+      "price_change_percentage_60d": -6.03827,
+      "price_change_percentage_200d": 0.97306,
+      "price_change_percentage_1y": 8.39795,
+      "market_cap_change_24h": 107970666,
+      "market_cap_change_percentage_24h": 3.25649,
+      "price_change_24h_in_currency": {
+        "usd": 0.20683
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.4653
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 3.2299
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 8.20861
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 31.63034
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 2.74172
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -6.03827
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 0.97306
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 8.39795
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 107970666
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 3.25649
+      },
+      "total_supply": 1000000000,
+      "max_supply": 1000000000,
+      "circulating_supply": 517099972.2305644,
+      "last_updated": "2023-07-03T17:48:56.086Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 41366,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:48:56.086Z"
+  },
+  {
+    "id": "convex-finance",
+    "symbol": "cvx",
+    "name": "Convex Finance",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Metagovernance", "Ethereum Ecosystem", "Decentralized Finance (DeFi)", "Yield Aggregator"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Convex is a protocol that simplifies Curve boosting experience in order to maximize yields. Convex allows Curve liquidity providers to earn trading fees and claim boosted CRV without locking CRV themselves. Liquidity providers can receive boosted CRV and liquidity mining rewards with minimal effort.\r\nIf you would like to stake CRV, Convex lets users receive trading fees as well as a share of boosted CRV received by liquidity providers. This allows for a better balance between liquidity providers and CRV stakers as well as better capital efficiency.\r\n\r\nCurve liquidity providers can deposit their LP tokens into Convex to maximize their CRV earnings with a more efficient boost.\r\n\r\nCurve DAO token stakers will be able to earn additional boosted CRV and CVX tokens through the protocol.\r\n\r\n"
+    },
+    "links": {
+      "homepage": ["https://www.convexfinance.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+        "https://ethplorer.io/address/0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/WHwgFwRG6h", "", ""],
+      "announcement_url": ["https://convexfinance.medium.com/", ""],
+      "twitter_screen_name": "convexfinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "convexEthChat",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/convex-eth/platform"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328",
+      "small": "https://assets.coingecko.com/coins/images/15585/small/convex.png?1621256328",
+      "large": "https://assets.coingecko.com/coins/images/15585/large/convex.png?1621256328"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+    "sentiment_votes_up_percentage": 50,
+    "sentiment_votes_down_percentage": 50,
+    "watchlist_portfolio_users": 29333,
+    "market_cap_rank": 117,
+    "coingecko_rank": 207,
+    "coingecko_score": 36.849,
+    "developer_score": 46.524,
+    "community_score": 9.123,
+    "liquidity_score": 42.507,
+    "public_interest_score": 0.008,
+    "market_data": {
+      "current_price": {
+        "usd": 3.94
+      },
+      "total_value_locked": {
+        "usd": 3262816772
+      },
+      "mcap_to_tvl_ratio": 0.09,
+      "fdv_to_tvl_ratio": 0.12,
+      "roi": null,
+      "ath": {
+        "usd": 60.09
+      },
+      "ath_change_percentage": {
+        "usd": -93.43378
+      },
+      "ath_date": {
+        "usd": "2022-01-01T18:04:03.030Z"
+      },
+      "atl": {
+        "usd": 1.9
+      },
+      "atl_change_percentage": {
+        "usd": 107.34307
+      },
+      "atl_date": {
+        "usd": "2021-07-20T13:17:29.183Z"
+      },
+      "market_cap": {
+        "usd": 309564418
+      },
+      "market_cap_rank": 117,
+      "fully_diluted_valuation": {
+        "usd": 394322558
+      },
+      "total_volume": {
+        "usd": 3199713
+      },
+      "high_24h": {
+        "usd": 3.95
+      },
+      "low_24h": {
+        "usd": 3.72
+      },
+      "price_change_24h": 0.223998,
+      "price_change_percentage_24h": 6.0227,
+      "price_change_percentage_7d": 8.68185,
+      "price_change_percentage_14d": 16.06446,
+      "price_change_percentage_30d": -7.52074,
+      "price_change_percentage_60d": -24.27528,
+      "price_change_percentage_200d": 5.38398,
+      "price_change_percentage_1y": -2.90973,
+      "market_cap_change_24h": 16665421,
+      "market_cap_change_percentage_24h": 5.68982,
+      "price_change_24h_in_currency": {
+        "usd": 0.223998
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.28953
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 6.0227
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 8.68185
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 16.06446
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -7.52074
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -24.27528
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 5.38398
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -2.90973
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 16665421
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 5.68982
+      },
+      "total_supply": 98500687.1736211,
+      "max_supply": 100000000,
+      "circulating_supply": 78505378.70365675,
+      "last_updated": "2023-07-03T17:50:31.974Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:50:31.974Z"
+  },
+  {
+    "id": "cow-protocol",
+    "symbol": "cow",
+    "name": "CoW Protocol",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+      "xdai": "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0x177127622c4a00f3d409b75571e12cb3c8973d3c"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Decentralized Exchange (DEX)",
+      "MEV Protection",
+      "Ethereum Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "Gnosis Chain Ecosystem"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "COW token allows its holders the right to govern and curate the infrastructure of the CoW Protocol ecosystem through the CowDAO. Additionally, COW token holders receive fee discounts when trading on CowSwap & some other perks."
+    },
+    "links": {
+      "homepage": ["https://cow.fi", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+        "https://ethplorer.io/address/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+        "https://blockscout.com/xdai/mainnet/token/0x177127622c4A00F3d409B75571e12cB3c8973d3c/token-transfers",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/cowprotocol", "", ""],
+      "announcement_url": ["https://medium.com/@cow-protocol", ""],
+      "twitter_screen_name": "CoWSwap",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/gnosis/cow-token/"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/24384/thumb/cow.png?1660960589",
+      "small": "https://assets.coingecko.com/coins/images/24384/small/cow.png?1660960589",
+      "large": "https://assets.coingecko.com/coins/images/24384/large/cow.png?1660960589"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 2852,
+    "market_cap_rank": 922,
+    "coingecko_rank": 625,
+    "coingecko_score": 25.574,
+    "developer_score": 50.117,
+    "community_score": 4.344,
+    "liquidity_score": 0.028,
+    "public_interest_score": 0.002,
+    "market_data": {
+      "current_price": {
+        "usd": 0.07317
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 2.22
+      },
+      "ath_change_percentage": {
+        "usd": -96.70271
+      },
+      "ath_date": {
+        "usd": "2022-03-28T16:24:17.921Z"
+      },
+      "atl": {
+        "usd": 0.03987045
+      },
+      "atl_change_percentage": {
+        "usd": 83.53302
+      },
+      "atl_date": {
+        "usd": "2022-11-09T18:32:42.225Z"
+      },
+      "market_cap": {
+        "usd": 10955385
+      },
+      "market_cap_rank": 922,
+      "fully_diluted_valuation": {
+        "usd": 73168377
+      },
+      "total_volume": {
+        "usd": 1903.97
+      },
+      "high_24h": {
+        "usd": 0.075087
+      },
+      "low_24h": {
+        "usd": 0.071219
+      },
+      "price_change_24h": -0.0003470444736227,
+      "price_change_percentage_24h": -0.47206,
+      "price_change_percentage_7d": -1.0501,
+      "price_change_percentage_14d": 7.79479,
+      "price_change_percentage_30d": -2.52199,
+      "price_change_percentage_60d": -1.00698,
+      "price_change_percentage_200d": -13.67381,
+      "price_change_percentage_1y": -14.51738,
+      "market_cap_change_24h": -72589.9166219,
+      "market_cap_change_percentage_24h": -0.65823,
+      "price_change_24h_in_currency": {
+        "usd": -0.000347044473622687
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.69357
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": -0.47206
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -1.0501
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 7.79479
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -2.52199
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -1.00698
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -13.67381
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -14.51738
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": -72589.9166219011
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -0.65823
+      },
+      "total_supply": 1000000000,
+      "max_supply": 1000000000,
+      "circulating_supply": 149728414.771927,
+      "last_updated": "2023-07-03T17:50:20.950Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:50:20.950Z"
+  },
+  {
+    "id": "curve-dao-token",
+    "symbol": "crv",
+    "name": "Curve DAO",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+      "polygon-pos": "0x172370d5cd63279efa6d502dab29171933a610af",
+      "fantom": "0x1e4f97b9f9f913c46f1632781732927b9019c68b",
+      "arbitrum-one": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+      "sora": "0x002ead91a2de57b8855b53d4a62c25277073fd7f65f7e5e79f4936ed747fcad0",
+      "energi": "0xd3319eaf3c4743ac75aace77befcfa445ed6e69e",
+      "optimistic-ethereum": "0x0994206dfe8de6ec6920ff4d779b0d950605fb53"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xd533a949740bb3306d119cc777fa900ba034cd52"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x172370d5cd63279efa6d502dab29171933a610af"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x1e4f97b9f9f913c46f1632781732927b9019c68b"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978"
+      },
+      "sora": {
+        "decimal_place": 18,
+        "contract_address": "0x002ead91a2de57b8855b53d4a62c25277073fd7f65f7e5e79f4936ed747fcad0"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0xd3319eaf3c4743ac75aace77befcfa445ed6e69e"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x0994206dfe8de6ec6920ff4d779b0d950605fb53"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Optimism Ecosystem",
+      "Fantom Ecosystem",
+      "Ethereum Ecosystem",
+      "Arbitrum Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Polygon Ecosystem",
+      "Exchange-based Tokens",
+      "Decentralized Exchange (DEX)",
+      "Automated Market Maker (AMM)",
+      "Yield Farming",
+      "Governance",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Similar to Uniswap, Curve Finance is an Automated Market Maker (AMM) based Decentralised Exchange (DEX). Unlike Uniswap, its main focus is only to swap between assets that are supposed to have the same value. This is useful in the DeFi ecosystem as there are plenty of wrapped tokens and synthetic tokens that aim to mimic the price of the real underlying asset. \r\n\r\nFor example, one of the biggest pools is 3CRV, which is a stablecoin pool consisting of DAI, USDT, and USDC. Their ratio in the pool will be based on the supply and demand of the market. Depositing a coin with a lesser ratio will yield the user a higher percentage of the pool. As such when the ratio is heavily tilted to one of the coins, it may serve as a good chance to arbitrage.\r\n\r\nCurve Finance also supports yield-bearing tokens. For example, it collaborated with Yearn Finance to release yUSD pools that consisted of yDAI, yUSDT, yUSDC and yTUSD. Users that participated in this pool will not only have yield from the underlying yield-bearing tokens, but also the swap fees generated by the Curve pool. Including the yield farming rewards in terms of CRV tokens, liquidity providers of the pool actually have three sources of yield. "
+    },
+    "links": {
+      "homepage": ["https://www.curve.fi/", "https://curve.eth.link/", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xd533a949740bb3306d119cc777fa900ba034cd52",
+        "https://ethplorer.io/address/0xd533a949740bb3306d119cc777fa900ba034cd52",
+        "https://polygonscan.com/token/0x172370d5cd63279efa6d502dab29171933a610af",
+        "https://arbiscan.io/token/0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+        "https://ftmscan.com/token/0x1e4f97b9f9f913c46f1632781732927b9019c68b",
+        "https://scan.meter.io/address/0x1e4f97b9f9f913c46f1632781732927b9019c68b",
+        "https://ftmscan.com/address/0x1e4f97b9f9f913c46f1632781732927b9019c68b",
+        "https://explorer.energi.network/token/0xd3319eaf3c4743ac75aace77befcfa445ed6e69e",
+        "https://optimistic.etherscan.io/token/0x0994206dfE8De6Ec6920FF4D779B0d950605Fb53",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/9uEHakc", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "curvefinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "curvefi",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/curvefi/curve-contract", "https://github.com/curvefi/curve-vue"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/12124/thumb/Curve.png?1597369484",
+      "small": "https://assets.coingecko.com/coins/images/12124/small/Curve.png?1597369484",
+      "large": "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1597369484"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+    "sentiment_votes_up_percentage": 86.67,
+    "sentiment_votes_down_percentage": 13.33,
+    "watchlist_portfolio_users": 92793,
+    "market_cap_rank": 72,
+    "coingecko_rank": 111,
+    "coingecko_score": 44.36,
+    "developer_score": 61.576,
+    "community_score": 10.746,
+    "liquidity_score": 59.03,
+    "public_interest_score": 0.035,
+    "market_data": {
+      "current_price": {
+        "usd": 0.781031
+      },
+      "total_value_locked": {
+        "usd": 3824878484
+      },
+      "mcap_to_tvl_ratio": 0.18,
+      "fdv_to_tvl_ratio": 0.67,
+      "roi": null,
+      "ath": {
+        "usd": 15.37
+      },
+      "ath_change_percentage": {
+        "usd": -94.91265
+      },
+      "ath_date": {
+        "usd": "2020-08-14T00:00:00.000Z"
+      },
+      "atl": {
+        "usd": 0.331577
+      },
+      "atl_change_percentage": {
+        "usd": 135.85213
+      },
+      "atl_date": {
+        "usd": "2020-11-05T13:09:50.181Z"
+      },
+      "market_cap": {
+        "usd": 677362077
+      },
+      "market_cap_rank": 72,
+      "fully_diluted_valuation": {
+        "usd": 2579767761
+      },
+      "total_volume": {
+        "usd": 33077647
+      },
+      "high_24h": {
+        "usd": 0.789882
+      },
+      "low_24h": {
+        "usd": 0.752729
+      },
+      "price_change_24h": 0.02414336,
+      "price_change_percentage_24h": 3.18982,
+      "price_change_percentage_7d": 15.19561,
+      "price_change_percentage_14d": 27.42801,
+      "price_change_percentage_30d": -8.2841,
+      "price_change_percentage_60d": -15.76328,
+      "price_change_percentage_200d": 26.37269,
+      "price_change_percentage_1y": -0.17004,
+      "market_cap_change_24h": 21222561,
+      "market_cap_change_percentage_24h": 3.23446,
+      "price_change_24h_in_currency": {
+        "usd": 0.02414336
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.35561
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 3.18982
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 15.19561
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 27.42801
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -8.2841
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -15.76328
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 26.37269
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -0.17004
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 21222561
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 3.23446
+      },
+      "total_supply": 1974501363.63616,
+      "max_supply": 3303030299,
+      "circulating_supply": 867267007,
+      "last_updated": "2023-07-03T17:50:14.867Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 14362,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:50:14.867Z"
+  },
+  {
+    "id": "dai",
+    "symbol": "dai",
+    "name": "Dai",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "polygon-zkevm": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
+      "kava": "0x765277eebeca2e31912c9946eae1021199b39c61",
+      "binance-smart-chain": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
+      "polygon-pos": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+      "optimistic-ethereum": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "metis-andromeda": "0x4651b38e7ec14bb3db731369bfe5b08f2466bd0a",
+      "harmony-shard-0": "0xef977d2f931c1978db5f6747666fa1eacb0d0339",
+      "avalanche": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "arbitrum-one": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "sora": "0x0200060000000000000000000000000000000000000000000000000000000000",
+      "moonriver": "0x80a16016cc4a2e6a2caca8a4a498b1699ff0f844",
+      "aurora": "0xe3520349f477a5f6eb06107066048508498a291b",
+      "cronos": "0xf2001b145b43032aaf5ee2884e456ccd805f677d",
+      "fantom": "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e",
+      "moonbeam": "0x765277eebeca2e31912c9946eae1021199b39c61",
+      "syscoin": "0xefaeee334f0fd1712f9a8cc375f427d9cdd40d73",
+      "milkomeda-cardano": "0x639a647fbe20b6c8ac19e48e2de44ea792c62c5c",
+      "energi": "0x0ee5893f434017d8881750101ea2f7c49c0eb503",
+      "cosmos": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "astar": "0x6de33698e9e9b787e09d3bd7771ef63557e148bb",
+      "arbitrum-nova": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "velas": "0xe3f5a90f9cb311505cd691a46596599aa1a0ad7d",
+      "klay-token": "0x078db7827a5531359f6cb63f62cfa20183c4f10c",
+      "xdai": "0x44fa8e6f47987339850636f88629646662444217",
+      "hydra": "abc2cd00700e06922bcf30fe0ad648507113cc56",
+      "near-protocol": "6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f"
+      },
+      "polygon-zkevm": {
+        "decimal_place": 18,
+        "contract_address": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4"
+      },
+      "kava": {
+        "decimal_place": 18,
+        "contract_address": "0x765277eebeca2e31912c9946eae1021199b39c61"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
+      },
+      "metis-andromeda": {
+        "decimal_place": 18,
+        "contract_address": "0x4651b38e7ec14bb3db731369bfe5b08f2466bd0a"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0xef977d2f931c1978db5f6747666fa1eacb0d0339"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
+      },
+      "sora": {
+        "decimal_place": 18,
+        "contract_address": "0x0200060000000000000000000000000000000000000000000000000000000000"
+      },
+      "moonriver": {
+        "decimal_place": 18,
+        "contract_address": "0x80a16016cc4a2e6a2caca8a4a498b1699ff0f844"
+      },
+      "aurora": {
+        "decimal_place": 18,
+        "contract_address": "0xe3520349f477a5f6eb06107066048508498a291b"
+      },
+      "cronos": {
+        "decimal_place": 18,
+        "contract_address": "0xf2001b145b43032aaf5ee2884e456ccd805f677d"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e"
+      },
+      "moonbeam": {
+        "decimal_place": 18,
+        "contract_address": "0x765277eebeca2e31912c9946eae1021199b39c61"
+      },
+      "syscoin": {
+        "decimal_place": 18,
+        "contract_address": "0xefaeee334f0fd1712f9a8cc375f427d9cdd40d73"
+      },
+      "milkomeda-cardano": {
+        "decimal_place": 18,
+        "contract_address": "0x639a647fbe20b6c8ac19e48e2de44ea792c62c5c"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0x0ee5893f434017d8881750101ea2f7c49c0eb503"
+      },
+      "cosmos": {
+        "decimal_place": 0,
+        "contract_address": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
+      },
+      "astar": {
+        "decimal_place": 18,
+        "contract_address": "0x6de33698e9e9b787e09d3bd7771ef63557e148bb"
+      },
+      "arbitrum-nova": {
+        "decimal_place": 18,
+        "contract_address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1"
+      },
+      "velas": {
+        "decimal_place": 18,
+        "contract_address": "0xe3f5a90f9cb311505cd691a46596599aa1a0ad7d"
+      },
+      "klay-token": {
+        "decimal_place": 18,
+        "contract_address": "0x078db7827a5531359f6cb63f62cfa20183c4f10c"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0x44fa8e6f47987339850636f88629646662444217"
+      },
+      "hydra": {
+        "decimal_place": null,
+        "contract_address": "abc2cd00700e06922bcf30fe0ad648507113cc56"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Harmony Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Velas Ecosystem",
+      "Optimism Ecosystem",
+      "Arbitrum Nova Ecosystem",
+      "Metis Ecosystem",
+      "Cronos Ecosystem",
+      "Ethereum Ecosystem",
+      "Moonbeam Ecosystem",
+      "Near Protocol Ecosystem",
+      "Fantom Ecosystem",
+      "Arbitrum Ecosystem",
+      "Moonriver Ecosystem",
+      "Avalanche Ecosystem",
+      "BNB Chain Ecosystem",
+      "Polygon Ecosystem",
+      "USD Stablecoin",
+      "Decentralized Finance (DeFi)",
+      "Stablecoins"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "MakerDAO has launched Multi-collateral DAI (MCD). This token refers to the new DAI that is collaterized by multiple assets.\r\n"
+    },
+    "links": {
+      "homepage": ["https://makerdao.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f",
+        "https://ethplorer.io/address/0x6b175474e89094c44da98b954eedeac495271d0f",
+        "https://blockchair.com/ethereum/erc-20/token/0x6b175474e89094c44da98b954eedeac495271d0f",
+        "https://arbiscan.io/token/0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        "https://polygonscan.com/token/0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "https://bscscan.com/token/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
+        "https://snowtrace.io/token/0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+        "https://avascan.info/blockchain/c/address/0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+        "https://explorer.mainnet.aurora.dev/token/0xe3520349f477a5f6eb06107066048508498a291b/token-transfers",
+        "https://moonriver.moonscan.io/token/0x80a16016cc4a2e6a2caca8a4a498b1699ff0f844"
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "MakerDAO",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "makerdaoOfficial",
+      "subreddit_url": "https://www.reddit.com/r/MakerDAO",
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/9956/thumb/Badge_Dai.png?1687143508",
+      "small": "https://assets.coingecko.com/coins/images/9956/small/Badge_Dai.png?1687143508",
+      "large": "https://assets.coingecko.com/coins/images/9956/large/Badge_Dai.png?1687143508"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+    "sentiment_votes_up_percentage": 25,
+    "sentiment_votes_down_percentage": 75,
+    "watchlist_portfolio_users": 43437,
+    "market_cap_rank": 19,
+    "coingecko_rank": 165,
+    "coingecko_score": 40.022,
+    "developer_score": 0,
+    "community_score": 41.386,
+    "liquidity_score": 69.787,
+    "public_interest_score": 0.018,
+    "market_data": {
+      "current_price": {
+        "usd": 0.999632
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1.22
+      },
+      "ath_change_percentage": {
+        "usd": -17.86418
+      },
+      "ath_date": {
+        "usd": "2020-03-13T03:02:50.373Z"
+      },
+      "atl": {
+        "usd": 0.88196
+      },
+      "atl_change_percentage": {
+        "usd": 13.51747
+      },
+      "atl_date": {
+        "usd": "2023-03-11T07:50:50.514Z"
+      },
+      "market_cap": {
+        "usd": 4335589769
+      },
+      "market_cap_rank": 19,
+      "fully_diluted_valuation": {
+        "usd": 4335589769
+      },
+      "total_volume": {
+        "usd": 151592455
+      },
+      "high_24h": {
+        "usd": 1.002
+      },
+      "low_24h": {
+        "usd": 0.99735
+      },
+      "price_change_24h": 0.00010455,
+      "price_change_percentage_24h": 0.01046,
+      "price_change_percentage_7d": -0.23471,
+      "price_change_percentage_14d": -0.04504,
+      "price_change_percentage_30d": -0.10212,
+      "price_change_percentage_60d": -0.03813,
+      "price_change_percentage_200d": -0.08741,
+      "price_change_percentage_1y": -0.20897,
+      "market_cap_change_24h": -8502863.32493,
+      "market_cap_change_percentage_24h": -0.19573,
+      "price_change_24h_in_currency": {
+        "usd": 0.00010455
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.11132
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.01046
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.23471
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -0.04504
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -0.10212
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -0.03813
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -0.08741
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -0.20897
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": -8502863.324930191
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -0.19573
+      },
+      "total_supply": 4331576020.13338,
+      "max_supply": 4331576020.13338,
+      "circulating_supply": 4330486358.07231,
+      "last_updated": "2023-07-03T17:50:00.610Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 30241,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:50:00.610Z"
+  },
+  {
+    "id": "daohaus",
+    "symbol": "haus",
+    "name": "DAOhaus",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+      "xdai": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xf2051511b9b121394fa75b8f7d4e7424337af687"
+      },
+      "xdai": {
+        "decimal_place": 35,
+        "contract_address": "0xb0c5f3100a4d9d9532a4cfd68c55f1ae8da987eb"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "Gnosis Chain Ecosystem", "Governance"],
+    "public_notice": null,
+    "additional_notices": [
+      "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
+    ],
+    "description": {
+      "en": "This HAUS doesn't build itself\r\nIt takes a community, and HausDAO is the community of contributors working together directly to design, build, and communicate the actual product."
+    },
+    "links": {
+      "homepage": ["https://daohaus.club/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xf2051511b9b121394fa75b8f7d4e7424337af687",
+        "https://ethplorer.io/address/0xf2051511b9b121394fa75b8f7d4e7424337af687",
+        "https://blockscout.com/xdai/mainnet/tokens/0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb/token-transfers",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/daohaus", "", ""],
+      "announcement_url": ["https://medium.com/daohaus-club/", ""],
+      "twitter_screen_name": "nowdaoit",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/HausDAO/pokemol-web"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14551/thumb/jN3kkqke_400x400.png?1616990048",
+      "small": "https://assets.coingecko.com/coins/images/14551/small/jN3kkqke_400x400.png?1616990048",
+      "large": "https://assets.coingecko.com/coins/images/14551/large/jN3kkqke_400x400.png?1616990048"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 926,
+    "market_cap_rank": 2190,
+    "coingecko_rank": 355,
+    "coingecko_score": 31.097,
+    "developer_score": 70.211,
+    "community_score": 8.208,
+    "liquidity_score": 1,
+    "public_interest_score": 0.003,
+    "market_data": {
+      "current_price": {
+        "usd": 0.648145
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 85.61
+      },
+      "ath_change_percentage": {
+        "usd": -99.24318
+      },
+      "ath_date": {
+        "usd": "2021-03-30T15:56:59.843Z"
+      },
+      "atl": {
+        "usd": 0.6395
+      },
+      "atl_change_percentage": {
+        "usd": 1.31732
+      },
+      "atl_date": {
+        "usd": "2023-07-02T19:19:46.426Z"
+      },
+      "market_cap": {
+        "usd": 648145
+      },
+      "market_cap_rank": 2190,
+      "fully_diluted_valuation": {
+        "usd": 648145
+      },
+      "total_volume": {
+        "usd": 21.94
+      },
+      "high_24h": {
+        "usd": 0.661424
+      },
+      "low_24h": {
+        "usd": 0.6395
+      },
+      "price_change_24h": 0.00516414,
+      "price_change_percentage_24h": 0.80316,
+      "price_change_percentage_7d": -22.18564,
+      "price_change_percentage_14d": -54.80497,
+      "price_change_percentage_30d": -58.16644,
+      "price_change_percentage_60d": -69.00674,
+      "price_change_percentage_200d": -79.91041,
+      "price_change_percentage_1y": -80.5227,
+      "market_cap_change_24h": 2217.71,
+      "market_cap_change_percentage_24h": 0.34334,
+      "price_change_24h_in_currency": {
+        "usd": 0.00516414
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.16151
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.80316
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -22.18564
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -54.80497
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -58.16644
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -69.00674
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -79.91041
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -80.5227
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 2217.71
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 0.34334
+      },
+      "total_supply": 1000000,
+      "max_supply": 1000000,
+      "circulating_supply": 1000000,
+      "last_updated": "2023-07-03T17:48:57.021Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:48:57.021Z"
+  },
+  {
+    "id": "diversified-staked-eth",
+    "symbol": "dseth",
+    "name": "Diversified Staked ETH",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x341c05c0e9b33c0e38d64de76516b2ce970bb3be"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x341c05c0e9b33c0e38d64de76516b2ce970bb3be"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem"],
+    "public_notice": "Anyone can mint new tokens, please proceed with caution.",
+    "additional_notices": [],
+    "description": {
+      "en": "The Diversified Staked ETH Index (dsETH) is an index token of the leading Ethereum liquid staking tokens. Along with providing a source of diversified staking yield, dsETH strengthens the Ethereum network with weightings that favor decentralized liquid staking protocols. "
+    },
+    "links": {
+      "homepage": ["https://indexcoop.com", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x341c05c0e9b33c0e38d64de76516b2ce970bb3be",
+        "https://ethplorer.io/address/0x341c05c0e9b33c0e38d64de76516b2ce970bb3be",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["https://www.linkedin.com/company/index-coop/", "", ""],
+      "chat_url": ["https://discord.gg/indexcoop", "https://indexcoop.com/blog", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/IndexCoop/index-protocol"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/28751/thumb/dsETH-logo.png?1673929867",
+      "small": "https://assets.coingecko.com/coins/images/28751/small/dsETH-logo.png?1673929867",
+      "large": "https://assets.coingecko.com/coins/images/28751/large/dsETH-logo.png?1673929867"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x341c05c0e9b33c0e38d64de76516b2ce970bb3be",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 70,
+    "market_cap_rank": 1752,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 2005.28
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 2153.61
+      },
+      "ath_change_percentage": {
+        "usd": -6.86851
+      },
+      "ath_date": {
+        "usd": "2023-04-16T19:25:40.546Z"
+      },
+      "atl": {
+        "usd": 1393.4
+      },
+      "atl_change_percentage": {
+        "usd": 43.94245
+      },
+      "atl_date": {
+        "usd": "2023-03-10T11:26:03.021Z"
+      },
+      "market_cap": {
+        "usd": 1609010
+      },
+      "market_cap_rank": 1752,
+      "fully_diluted_valuation": {
+        "usd": 1609010
+      },
+      "total_volume": {
+        "usd": 16042.27
+      },
+      "high_24h": {
+        "usd": 2011.37
+      },
+      "low_24h": {
+        "usd": 1947.24
+      },
+      "price_change_24h": 54.08,
+      "price_change_percentage_24h": 2.7718,
+      "price_change_percentage_7d": 5.64893,
+      "price_change_percentage_14d": 14.18345,
+      "price_change_percentage_30d": 3.88869,
+      "price_change_percentage_60d": 5.02459,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": 39819,
+      "market_cap_change_percentage_24h": 2.53754,
+      "price_change_24h_in_currency": {
+        "usd": 54.08
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.06864
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.7718
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 5.64893
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 14.18345
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 3.88869
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 5.02459
+      },
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {
+        "usd": 39819
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.53754
+      },
+      "total_supply": 802.385281791854,
+      "max_supply": null,
+      "circulating_supply": 802.385281791854,
+      "last_updated": "2023-07-03T17:49:51.745Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:49:51.745Z"
+  },
+  {
+    "id": "eden",
+    "symbol": "eden",
+    "name": "EDEN",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "MEV Protection"],
+    "public_notice": "<a href=\"https://www.coingecko.com/en/coins/archer-dao-governance-token?locale=en\">ARCH</a> is currently undergoing migration to EDEN. For more information, visit https://medium.com/archer-dao/arch-token-migration-915e6af976c6.",
+    "additional_notices": [],
+    "description": {
+      "en": "Eden is a priority transaction network that protects traders from frontrunning, aligns incentives for block producers, and redistributes miner extractable value."
+    },
+    "links": {
+      "homepage": ["https://www.edennetwork.io/", "https://medium.com/edennetwork", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
+        "https://ethplorer.io/address/0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.io/edennetwork", "", ""],
+      "announcement_url": ["https://medium.com/archer-dao", ""],
+      "twitter_screen_name": "edennetwork",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "archerdao",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/eden-network"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/17470/thumb/Iyc0XM5-_400x400.jpg?1628254655",
+      "small": "https://assets.coingecko.com/coins/images/17470/small/Iyc0XM5-_400x400.jpg?1628254655",
+      "large": "https://assets.coingecko.com/coins/images/17470/large/Iyc0XM5-_400x400.jpg?1628254655"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559",
+    "sentiment_votes_up_percentage": 0,
+    "sentiment_votes_down_percentage": 100,
+    "watchlist_portfolio_users": 5878,
+    "market_cap_rank": 1264,
+    "coingecko_rank": 1262,
+    "coingecko_score": 19.387,
+    "developer_score": 0,
+    "community_score": 8.311,
+    "liquidity_score": 27.324,
+    "public_interest_score": 0.002,
+    "market_data": {
+      "current_price": {
+        "usd": 0.0333038
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 9.27
+      },
+      "ath_change_percentage": {
+        "usd": -99.64052
+      },
+      "ath_date": {
+        "usd": "2021-09-08T19:31:10.058Z"
+      },
+      "atl": {
+        "usd": 0
+      },
+      "atl_change_percentage": {
+        "usd": 4.5610913941744506e35
+      },
+      "atl_date": {
+        "usd": "2021-08-03T18:56:38.176Z"
+      },
+      "market_cap": {
+        "usd": 4121660
+      },
+      "market_cap_rank": 1264,
+      "fully_diluted_valuation": {
+        "usd": 8324204
+      },
+      "total_volume": {
+        "usd": 72551
+      },
+      "high_24h": {
+        "usd": 0.03355169
+      },
+      "low_24h": {
+        "usd": 0.03278129
+      },
+      "price_change_24h": 0.00034227,
+      "price_change_percentage_24h": 1.03838,
+      "price_change_percentage_7d": -9.61445,
+      "price_change_percentage_14d": 0.58043,
+      "price_change_percentage_30d": -15.79427,
+      "price_change_percentage_60d": -49.20921,
+      "price_change_percentage_200d": -43.51389,
+      "price_change_percentage_1y": -59.55722,
+      "market_cap_change_24h": 45578,
+      "market_cap_change_percentage_24h": 1.11818,
+      "price_change_24h_in_currency": {
+        "usd": 0.00034227
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.05668
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 1.03838
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -9.61445
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 0.58043
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -15.79427
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -49.20921
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -43.51389
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -59.55722
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 45578
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 1.11818
+      },
+      "total_supply": 146385393.660009,
+      "max_supply": 250000000,
+      "circulating_supply": 123785393.660009,
+      "last_updated": "2023-07-03T17:51:05.419Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:51:05.419Z"
+  },
+  {
+    "id": "fei-usd",
+    "symbol": "fei",
+    "name": "Fei USD",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x956f47f50a910163d8bf957cf5846d573e7f87ca"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "USD Stablecoin",
+      "Ethereum Ecosystem",
+      "Stablecoins",
+      "Decentralized Finance (DeFi)",
+      "Asset-backed Tokens"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "FEI uses a new kind of stablecoin mechanism called protocol controlled value (PCV). It is more capital-efficient, has a fair distribution, and is fully decentralized. The protocol uses the value it controls to maintain liquid secondary markets.\r\n\r\nFei Labs is the team that created FEI, a highly scalable, decentralized, and reserve-backed stablecoin that can meet DeFi’s needs without relying on centralized assets for collateral, that unlocks next-generation integration potential. Our mission is to be the stable coin of DeFi backed by some of the top minds in the space, including a16z, Nascent, Variant, Coinbase,\r\n\r\nFei v2 launches in late 2021, bringing 1:1 redeemability, TRIBE buybacks/backstop, and algorithmic PCV management: https://medium.com/fei-protocol/introducing-fei-v2-6f56afe7a1b5"
+    },
+    "links": {
+      "homepage": ["https://fei.money/", "https://app.fei.money/", "https://docs.fei.money/"],
+      "blockchain_site": [
+        "https://etherscan.io/address/0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
+        "https://etherscan.io/token/0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+        "https://ethplorer.io/address/0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/2prhYdQ5jP", "", ""],
+      "announcement_url": ["https://medium.com/@fei-protocol", ""],
+      "twitter_screen_name": "feiprotocol",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "feiprotocol",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14570/thumb/ZqsF51Re_400x400.png?1617082206",
+      "small": "https://assets.coingecko.com/coins/images/14570/small/ZqsF51Re_400x400.png?1617082206",
+      "large": "https://assets.coingecko.com/coins/images/14570/large/ZqsF51Re_400x400.png?1617082206"
+    },
+    "country_origin": "US",
+    "genesis_date": null,
+    "contract_address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 3806,
+    "market_cap_rank": 519,
+    "coingecko_rank": 886,
+    "coingecko_score": 22.298,
+    "developer_score": 0,
+    "community_score": 9.127,
+    "liquidity_score": 32.341,
+    "public_interest_score": 0.001,
+    "market_data": {
+      "current_price": {
+        "usd": 0.976458
+      },
+      "total_value_locked": {
+        "usd": 6.18
+      },
+      "mcap_to_tvl_ratio": 5463529.05,
+      "fdv_to_tvl_ratio": 5504423.25,
+      "roi": null,
+      "ath": {
+        "usd": 1.6
+      },
+      "ath_change_percentage": {
+        "usd": -39.13027
+      },
+      "ath_date": {
+        "usd": "2023-04-23T10:41:30.842Z"
+      },
+      "atl": {
+        "usd": 0.61038
+      },
+      "atl_change_percentage": {
+        "usd": 59.7258
+      },
+      "atl_date": {
+        "usd": "2023-04-09T16:41:35.657Z"
+      },
+      "market_cap": {
+        "usd": 33740839
+      },
+      "market_cap_rank": 519,
+      "fully_diluted_valuation": {
+        "usd": 33993387
+      },
+      "total_volume": {
+        "usd": 46847
+      },
+      "high_24h": {
+        "usd": 0.986421
+      },
+      "low_24h": {
+        "usd": 0.957836
+      },
+      "price_change_24h": 0.01169659,
+      "price_change_percentage_24h": 1.21238,
+      "price_change_percentage_7d": -2.71681,
+      "price_change_percentage_14d": -2.16392,
+      "price_change_percentage_30d": -0.38324,
+      "price_change_percentage_60d": 2.35271,
+      "price_change_percentage_200d": -0.84745,
+      "price_change_percentage_1y": -2.15332,
+      "market_cap_change_24h": 437098,
+      "market_cap_change_percentage_24h": 1.31246,
+      "price_change_24h_in_currency": {
+        "usd": 0.01169659
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.46042
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 1.21238
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -2.71681
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -2.16392
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -0.38324
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 2.35271
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -0.84745
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -2.15332
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 437098
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 1.31246
+      },
+      "total_supply": 34823763.193664,
+      "max_supply": 34823763.193664,
+      "circulating_supply": 34565045.793891504,
+      "last_updated": "2023-07-03T17:51:55.805Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:51:55.805Z"
+  },
+  {
+    "id": "flux-dai",
+    "symbol": "fdai",
+    "name": "Flux DAI",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xe2ba8693ce7474900a045757fe0efca900f6530b"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 8,
+        "contract_address": "0xe2ba8693ce7474900a045757fe0efca900f6530b"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [],
+    "public_notice": null,
+    "additional_notices": [
+      "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
+    ],
+    "description": {
+      "en": "What is fDAI?\r\nEach asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fDAI, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets. \r\n\r\nWhat Makes fDAI Unique?\r\nfDAI is minted when users deposit DAI on Flux Finance. By doing so, the user's DAI will become available to borrowers, and the user will earn the DAI supply rate. fDAI increases in value relative to the underlying DAI, meaning users can redeem more assets over time as interest is earned. The interest rate earned by lenders fluctuates and depends on the market's utilization (i.e. the percentage of deposited assets that have been borrowed).\r\n\r\nHistory of fDAI\r\nIn January 2023, Flux was announced as a decentralized lending protocol that can support permissionless cryptoassets alongside permissioned tokens. The protocol was initially developed by Ondo Finance, a software development firm in DeFi, before being sold to Flux Finance.\r\n\r\nFlux is governed by the Ondo DAO, in which ONDO holders vote to upgrade its code and alter its risk parameters. In February 2023, the protocol was initialized and its supported assets and parameters were selected in a genesis vote. fDAI was among the first assets to be selected, alongside fUSDC and fOUSG. Markets for these assets opened shortly after.\r\n\r\nWhat can fDAI be Used For?\r\nBy minting fDAI, users earn interest and gain the ability to use fDAI as collateral. fDAI can be transferred to effect change in ownership. Transferring fDAI means transferring your balance of the underlying DAI inside the Flux Finance protocol. Transfers that would result in negative account liquidity for borrowers on Flux Finance will fail.\r\n\r\nWhat’s Next for fDAI?\r\nAs a permissionless yielding asset, fDAI can in turn be used as collateral at other lending protocols, and offers an alternative settlement option between parties."
+    },
+    "links": {
+      "homepage": ["https://fluxfinance.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xe2bA8693cE7474900A045757fe0efCa900F6530b",
+        "https://ethplorer.io/address/0xe2bA8693cE7474900A045757fe0efCa900F6530b",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/YzhZaFbB92", "https://blog.fluxfinance.com/", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "FluxDeFi",
+      "facebook_username": null,
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "+feNWURgESeoyMmRh",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/29052/thumb/fDAI_200x200.png?1676335235",
+      "small": "https://assets.coingecko.com/coins/images/29052/small/fDAI_200x200.png?1676335235",
+      "large": "https://assets.coingecko.com/coins/images/29052/large/fDAI_200x200.png?1676335235"
+    },
+    "country_origin": null,
+    "genesis_date": null,
+    "contract_address": "0xe2ba8693ce7474900a045757fe0efca900f6530b",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 4,
+    "market_cap_rank": null,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {},
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {},
+      "ath_change_percentage": {
+        "usd": 0
+      },
+      "ath_date": {},
+      "atl": {},
+      "atl_change_percentage": {
+        "usd": 0
+      },
+      "atl_date": {},
+      "market_cap": {},
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {},
+      "total_volume": {},
+      "high_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "low_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "price_change_24h": null,
+      "price_change_percentage_24h": null,
+      "price_change_percentage_7d": 0,
+      "price_change_percentage_14d": 0,
+      "price_change_percentage_30d": 0,
+      "price_change_percentage_60d": 0,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": null,
+      "market_cap_change_percentage_24h": null,
+      "price_change_24h_in_currency": {},
+      "price_change_percentage_1h_in_currency": {},
+      "price_change_percentage_24h_in_currency": {},
+      "price_change_percentage_7d_in_currency": {},
+      "price_change_percentage_14d_in_currency": {},
+      "price_change_percentage_30d_in_currency": {},
+      "price_change_percentage_60d_in_currency": {},
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {},
+      "market_cap_change_percentage_24h_in_currency": {},
+      "total_supply": null,
+      "max_supply": null,
+      "circulating_supply": null,
+      "last_updated": null
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": null
+  },
+  {
+    "id": "flux-frax",
+    "symbol": "ffrax",
+    "name": "Flux FRAX",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 8,
+        "contract_address": "0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [],
+    "public_notice": null,
+    "additional_notices": [
+      "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
+    ],
+    "description": {
+      "en": "Each asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fFRAX, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets."
+    },
+    "links": {
+      "homepage": ["https://fluxfinance.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x1C9A2d6b33B4826757273D47ebEe0e2DddcD978B",
+        "https://ethplorer.io/address/0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.fluxfinance.com/", "https://blog.fluxfinance.com/", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "FluxDeFi",
+      "facebook_username": null,
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": null,
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/29580/thumb/fFRAX-320.png?1679813767",
+      "small": "https://assets.coingecko.com/coins/images/29580/small/fFRAX-320.png?1679813767",
+      "large": "https://assets.coingecko.com/coins/images/29580/large/fFRAX-320.png?1679813767"
+    },
+    "country_origin": null,
+    "genesis_date": null,
+    "contract_address": "0x1c9a2d6b33b4826757273d47ebee0e2dddcd978b",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 4,
+    "market_cap_rank": null,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {},
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {},
+      "ath_change_percentage": {
+        "usd": 0
+      },
+      "ath_date": {},
+      "atl": {},
+      "atl_change_percentage": {
+        "usd": 0
+      },
+      "atl_date": {},
+      "market_cap": {},
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {},
+      "total_volume": {},
+      "high_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "low_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "price_change_24h": null,
+      "price_change_percentage_24h": null,
+      "price_change_percentage_7d": 0,
+      "price_change_percentage_14d": 0,
+      "price_change_percentage_30d": 0,
+      "price_change_percentage_60d": 0,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": null,
+      "market_cap_change_percentage_24h": null,
+      "price_change_24h_in_currency": {},
+      "price_change_percentage_1h_in_currency": {},
+      "price_change_percentage_24h_in_currency": {},
+      "price_change_percentage_7d_in_currency": {},
+      "price_change_percentage_14d_in_currency": {},
+      "price_change_percentage_30d_in_currency": {},
+      "price_change_percentage_60d_in_currency": {},
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {},
+      "market_cap_change_percentage_24h_in_currency": {},
+      "total_supply": null,
+      "max_supply": null,
+      "circulating_supply": null,
+      "last_updated": null
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": null
+  },
+  {
+    "id": "flux-usdc",
+    "symbol": "fusdc",
+    "name": "Flux USDC",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x465a5a630482f3abd6d3b84b39b29b07214d19e5"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 8,
+        "contract_address": "0x465a5a630482f3abd6d3b84b39b29b07214d19e5"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [],
+    "public_notice": null,
+    "additional_notices": [
+      "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
+    ],
+    "description": {
+      "en": "What is fUSDC?\r\nEach asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fUSDC, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets. \r\n\r\nWhat Makes fUSDC Unique?\r\nfUSDC is minted when users deposit USDC on Flux Finance. By doing so, the user's USDC will become available to borrowers, and the user will earn the USDC supply rate. fUSDC increases in value relative to the underlying USDC, meaning users can redeem more assets over time as interest is earned. The interest rate earned by lenders fluctuates and depends on the market's utilization (i.e. the percentage of deposited assets that have been borrowed).\r\n\r\nHistory of fUSDC\r\nIn January 2023, Flux was announced as a decentralized lending protocol that can support permissionless cryptoassets alongside permissioned tokens. The protocol was initially developed by Ondo Finance, a software development firm in DeFi, before being sold to Flux Finance.\r\n\r\nFlux is governed by the Ondo DAO, in which ONDO holders vote to upgrade its code and alter its risk parameters. In February 2023, the protocol was initialized and its supported assets and parameters were selected in a genesis vote. fUSDC was among the first assets to be selected, alongside fDAI and fOUSG. Markets for these assets opened shortly after.\r\n\r\nWhat can fUSDC be Used For?\r\nBy minting fUSDC, users earn interest and gain the ability to use fUSDC as collateral. fUSDC can be transferred to effect change in ownership. Transferring fUSDC means transferring your balance of the underlying USDC inside the Flux Finance protocol. Transfers that would result in negative account liquidity for borrowers on Flux Finance will fail.\r\n\r\nWhat’s Next for fUSDC?\r\nAs a permissionless yielding asset, fUSDC can in turn be used as collateral at other lending protocols, and offers an alternative settlement option between parties.\r\n"
+    },
+    "links": {
+      "homepage": ["https://fluxfinance.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x465a5a630482f3abD6d3b84B39B29b07214d19e5",
+        "https://ethplorer.io/address/0x465a5a630482f3abD6d3b84B39B29b07214d19e5",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/YzhZaFbB92", "https://blog.fluxfinance.com/", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "FluxDeFi",
+      "facebook_username": null,
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "+feNWURgESeoyMmRh",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/29051/thumb/fUSDC_200x200.png?1676335208",
+      "small": "https://assets.coingecko.com/coins/images/29051/small/fUSDC_200x200.png?1676335208",
+      "large": "https://assets.coingecko.com/coins/images/29051/large/fUSDC_200x200.png?1676335208"
+    },
+    "country_origin": null,
+    "genesis_date": null,
+    "contract_address": "0x465a5a630482f3abd6d3b84b39b29b07214d19e5",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 2,
+    "market_cap_rank": null,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {},
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {},
+      "ath_change_percentage": {
+        "usd": 0
+      },
+      "ath_date": {},
+      "atl": {},
+      "atl_change_percentage": {
+        "usd": 0
+      },
+      "atl_date": {},
+      "market_cap": {},
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {},
+      "total_volume": {},
+      "high_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "low_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "price_change_24h": null,
+      "price_change_percentage_24h": null,
+      "price_change_percentage_7d": 0,
+      "price_change_percentage_14d": 0,
+      "price_change_percentage_30d": 0,
+      "price_change_percentage_60d": 0,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": null,
+      "market_cap_change_percentage_24h": null,
+      "price_change_24h_in_currency": {},
+      "price_change_percentage_1h_in_currency": {},
+      "price_change_percentage_24h_in_currency": {},
+      "price_change_percentage_7d_in_currency": {},
+      "price_change_percentage_14d_in_currency": {},
+      "price_change_percentage_30d_in_currency": {},
+      "price_change_percentage_60d_in_currency": {},
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {},
+      "market_cap_change_percentage_24h_in_currency": {},
+      "total_supply": null,
+      "max_supply": null,
+      "circulating_supply": null,
+      "last_updated": null
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": null
+  },
+  {
+    "id": "flux-usdt",
+    "symbol": "fusdt",
+    "name": "Flux USDT",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 8,
+        "contract_address": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [],
+    "public_notice": null,
+    "additional_notices": [
+      "No active trades are found for this coin. Please submit a ticket at %{link} if you think this is an error."
+    ],
+    "description": {
+      "en": "Each asset supported by the Flux Finance Protocol is integrated through a fToken contract, which is a representation of balances supplied to the protocol. fTokens, such as fUSDT, are a fork of Compound V2's cTokens, with additional functionality to support permissioned assets. "
+    },
+    "links": {
+      "homepage": ["https://fluxfinance.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x81994b9607e06ab3d5cF3AffF9a67374f05F27d7",
+        "https://ethplorer.io/address/0x81994b9607e06ab3d5cf3afff9a67374f05f27d7",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://www.discord.fluxfinance.com", "https://blog.fluxfinance.com/", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "FluxDeFi",
+      "facebook_username": null,
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": null,
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/29581/thumb/fUSDT-320.png?1679813769",
+      "small": "https://assets.coingecko.com/coins/images/29581/small/fUSDT-320.png?1679813769",
+      "large": "https://assets.coingecko.com/coins/images/29581/large/fUSDT-320.png?1679813769"
+    },
+    "country_origin": null,
+    "genesis_date": null,
+    "contract_address": "0x81994b9607e06ab3d5cf3afff9a67374f05f27d7",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 21,
+    "market_cap_rank": null,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {},
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {},
+      "ath_change_percentage": {
+        "usd": 0
+      },
+      "ath_date": {},
+      "atl": {},
+      "atl_change_percentage": {
+        "usd": 0
+      },
+      "atl_date": {},
+      "market_cap": {},
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {},
+      "total_volume": {},
+      "high_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "low_24h": {
+        "AED": null,
+        "ARS": null,
+        "AUD": null,
+        "BCH": null,
+        "BDT": null,
+        "BHD": null,
+        "BMD": null,
+        "BNB": null,
+        "BRL": null,
+        "BTC": null,
+        "CAD": null,
+        "CHF": null,
+        "CLP": null,
+        "CNY": null,
+        "CZK": null,
+        "DKK": null,
+        "DOT": null,
+        "EOS": null,
+        "ETH": null,
+        "EUR": null,
+        "GBP": null,
+        "HKD": null,
+        "HUF": null,
+        "IDR": null,
+        "ILS": null,
+        "INR": null,
+        "JPY": null,
+        "KRW": null,
+        "KWD": null,
+        "LKR": null,
+        "LTC": null,
+        "MMK": null,
+        "MXN": null,
+        "MYR": null,
+        "NGN": null,
+        "NOK": null,
+        "NZD": null,
+        "PHP": null,
+        "PKR": null,
+        "PLN": null,
+        "RUB": null,
+        "SAR": null,
+        "SEK": null,
+        "SGD": null,
+        "THB": null,
+        "TRY": null,
+        "TWD": null,
+        "UAH": null,
+        "USD": null,
+        "VEF": null,
+        "VND": null,
+        "XAG": null,
+        "XAU": null,
+        "XDR": null,
+        "XLM": null,
+        "XRP": null,
+        "YFI": null,
+        "ZAR": null,
+        "BITS": null,
+        "LINK": null,
+        "SATS": null
+      },
+      "price_change_24h": null,
+      "price_change_percentage_24h": null,
+      "price_change_percentage_7d": 0,
+      "price_change_percentage_14d": 0,
+      "price_change_percentage_30d": 0,
+      "price_change_percentage_60d": 0,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": null,
+      "market_cap_change_percentage_24h": null,
+      "price_change_24h_in_currency": {},
+      "price_change_percentage_1h_in_currency": {},
+      "price_change_percentage_24h_in_currency": {},
+      "price_change_percentage_7d_in_currency": {},
+      "price_change_percentage_14d_in_currency": {},
+      "price_change_percentage_30d_in_currency": {},
+      "price_change_percentage_60d_in_currency": {},
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {},
+      "market_cap_change_percentage_24h_in_currency": {},
+      "total_supply": null,
+      "max_supply": null,
+      "circulating_supply": null,
+      "last_updated": null
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": null
+  },
+  {
+    "id": "frax",
+    "symbol": "frax",
+    "name": "Frax",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x853d955acef822db058eb8505911ed77f175b99e",
+      "optimistic-ethereum": "0x2e3d870790dc77a83dd1d18184acc7439a53f475",
+      "near-protocol": "853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near",
+      "polygon-zkevm": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d",
+      "moonbeam": "0x322e86852e492a7ee17f28a78c663da38fb33bfb",
+      "binance-smart-chain": "0x90c97f71e18723b0cf0dfa30ee176ab653e89f40",
+      "avalanche": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
+      "polygon-pos": "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89",
+      "fantom": "0xdc301622e621166bd8e82f2ca0a26c13ad0be355",
+      "harmony-shard-0": "0xfa7191d292d5633f702b0bd7e3e3bccc0e633200",
+      "arbitrum-one": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
+      "moonriver": "0x1a93b23281cc1cde4c4741353f3064709a16197d",
+      "solana": "FR87nWEUxVgerFGhZM8Y4AggKGLnaXswr1Pd8wZ4kZcp",
+      "evmos": "0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x853d955acef822db058eb8505911ed77f175b99e"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x2e3d870790dc77a83dd1d18184acc7439a53f475"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near"
+      },
+      "polygon-zkevm": {
+        "decimal_place": 18,
+        "contract_address": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d"
+      },
+      "moonbeam": {
+        "decimal_place": 18,
+        "contract_address": "0x322e86852e492a7ee17f28a78c663da38fb33bfb"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0x90c97f71e18723b0cf0dfa30ee176ab653e89f40"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0xdc301622e621166bd8e82f2ca0a26c13ad0be355"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0xfa7191d292d5633f702b0bd7e3e3bccc0e633200"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x17fc002b466eec40dae837fc4be5c67993ddbd6f"
+      },
+      "moonriver": {
+        "decimal_place": 18,
+        "contract_address": "0x1a93b23281cc1cde4c4741353f3064709a16197d"
+      },
+      "solana": {
+        "decimal_place": 18,
+        "contract_address": "FR87nWEUxVgerFGhZM8Y4AggKGLnaXswr1Pd8wZ4kZcp"
+      },
+      "evmos": {
+        "decimal_place": 18,
+        "contract_address": "0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Solana Ecosystem",
+      "Moonbeam Ecosystem",
+      "Optimism Ecosystem",
+      "Harmony Ecosystem",
+      "Arbitrum Ecosystem",
+      "Fantom Ecosystem",
+      "Ethereum Ecosystem",
+      "BNB Chain Ecosystem",
+      "Moonriver Ecosystem",
+      "USD Stablecoin",
+      "Polygon Ecosystem",
+      "Avalanche Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "Stablecoins",
+      "Seigniorage"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "The first fractional-algorithmic stablecoin"
+    },
+    "links": {
+      "homepage": ["https://frax.finance", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x853d955acef822db058eb8505911ed77f175b99e",
+        "https://ethplorer.io/address/0x853d955acef822db058eb8505911ed77f175b99e",
+        "https://polygonscan.com/token/0x45c32fA6DF82ead1e2EF74d17b76547EDdFaFF89",
+        "https://bscscan.com/token/0x90C97F71E18723b0Cf0dfa30ee176Ab653E89F40",
+        "https://avascan.info/blockchain/c/address/0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64",
+        "https://snowtrace.io/token/0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
+        "https://moonriver.moonscan.io/token/0x1a93b23281cc1cde4c4741353f3064709a16197d",
+        "https://arbiscan.io/token/0x17fc002b466eec40dae837fc4be5c67993ddbd6f",
+        "https://nearblocks.io/token/853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near",
+        "https://scan.meter.io/address/0xdc301622e621166bd8e82f2ca0a26c13ad0be355"
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/MTZu6Hf57d", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "fraxfinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "fraxfinance",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/fraxfinance/frax-solidity"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/13422/thumb/FRAX_icon.png?1679886922",
+      "small": "https://assets.coingecko.com/coins/images/13422/small/FRAX_icon.png?1679886922",
+      "large": "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1679886922"
+    },
+    "country_origin": "KY",
+    "genesis_date": null,
+    "contract_address": "0x853d955acef822db058eb8505911ed77f175b99e",
+    "sentiment_votes_up_percentage": 33.33,
+    "sentiment_votes_down_percentage": 66.67,
+    "watchlist_portfolio_users": 8706,
+    "market_cap_rank": 44,
+    "coingecko_rank": 566,
+    "coingecko_score": 26.382,
+    "developer_score": 0,
+    "community_score": 9.224,
+    "liquidity_score": 42.81,
+    "public_interest_score": 0.005,
+    "market_data": {
+      "current_price": {
+        "usd": 1
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1.14
+      },
+      "ath_change_percentage": {
+        "usd": -12.3117
+      },
+      "ath_date": {
+        "usd": "2021-02-07T12:55:35.766Z"
+      },
+      "atl": {
+        "usd": 0.874536
+      },
+      "atl_change_percentage": {
+        "usd": 14.35114
+      },
+      "atl_date": {
+        "usd": "2023-03-11T07:50:39.316Z"
+      },
+      "market_cap": {
+        "usd": 1003597034
+      },
+      "market_cap_rank": 44,
+      "fully_diluted_valuation": {
+        "usd": 1003597034
+      },
+      "total_volume": {
+        "usd": 9337473
+      },
+      "high_24h": {
+        "usd": 1.003
+      },
+      "low_24h": {
+        "usd": 0.994691
+      },
+      "price_change_24h": 0.00133968,
+      "price_change_percentage_24h": 0.13414,
+      "price_change_percentage_7d": -0.16954,
+      "price_change_percentage_14d": 0.11433,
+      "price_change_percentage_30d": 0.19081,
+      "price_change_percentage_60d": 0.07221,
+      "price_change_percentage_200d": 0.14668,
+      "price_change_percentage_1y": 0.06423,
+      "market_cap_change_24h": -308118.72356,
+      "market_cap_change_percentage_24h": -0.03069,
+      "price_change_24h_in_currency": {
+        "usd": 0.00133968
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.00396
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.13414
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.16954
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 0.11433
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 0.19081
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 0.07221
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 0.14668
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 0.06423
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": -308118.7235612869
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -0.03069
+      },
+      "total_supply": 1004141409.40878,
+      "max_supply": 1004141409.40878,
+      "circulating_supply": 1004141409.40878,
+      "last_updated": "2023-07-03T17:54:34.546Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:54:34.546Z"
+  },
+  {
+    "id": "frax-share",
+    "symbol": "fxs",
+    "name": "Frax Share",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+      "polygon-zkevm": "0x6b856a14cea1d7dcfaf80fa6936c0b75972ccace",
+      "solana": "6LX8BhMQ4Sy2otmAWj7Y5sKd9YTVVUgfMsBzT6B9W7ct",
+      "binance-smart-chain": "0xe48a3d7d0bc88d552f730b62c006bc925eadb9ee",
+      "polygon-pos": "0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
+      "avalanche": "0x214db107654ff987ad859f34125307783fc8e387",
+      "fantom": "0x7d016eec9c25232b01f23ef992d98ca97fc2af5a",
+      "arbitrum-one": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
+      "harmony-shard-0": "0x0767d8e1b05efa8d6a301a65b324b6b66a1cc14c",
+      "moonriver": "0x6f1d1ee50846fcbc3de91723e61cb68cfa6d0e98",
+      "evmos": "0xd8176865dd0d672c6ab4a427572f80a72b4b4a9c"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0"
+      },
+      "polygon-zkevm": {
+        "decimal_place": 18,
+        "contract_address": "0x6b856a14cea1d7dcfaf80fa6936c0b75972ccace"
+      },
+      "solana": {
+        "decimal_place": 18,
+        "contract_address": "6LX8BhMQ4Sy2otmAWj7Y5sKd9YTVVUgfMsBzT6B9W7ct"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xe48a3d7d0bc88d552f730b62c006bc925eadb9ee"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x1a3acf6d19267e2d3e7f898f42803e90c9219062"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x214db107654ff987ad859f34125307783fc8e387"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x7d016eec9c25232b01f23ef992d98ca97fc2af5a"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0x0767d8e1b05efa8d6a301a65b324b6b66a1cc14c"
+      },
+      "moonriver": {
+        "decimal_place": 18,
+        "contract_address": "0x6f1d1ee50846fcbc3de91723e61cb68cfa6d0e98"
+      },
+      "evmos": {
+        "decimal_place": 18,
+        "contract_address": "0xd8176865dd0d672c6ab4a427572f80a72b4b4a9c"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Solana Ecosystem",
+      "Liquid Staking Governance Tokens",
+      "Harmony Ecosystem",
+      "Ethereum Ecosystem",
+      "Moonriver Ecosystem",
+      "Arbitrum Ecosystem",
+      "Fantom Ecosystem",
+      "Polygon Ecosystem",
+      "BNB Chain Ecosystem",
+      "Olympus Pro",
+      "Avalanche Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "Seigniorage"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "The Frax Share token is the governance and value accrual token of the Frax Stablecoin Protocol"
+    },
+    "links": {
+      "homepage": ["https://frax.finance", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+        "https://ethplorer.io/address/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+        "https://bscscan.com/token/0xe48A3d7d0Bc88d552f730B62c006bC925eadB9eE",
+        "https://ftmscan.com/token/0x7d016eec9c25232b01f23ef992d98ca97fc2af5a",
+        "https://arbiscan.io/token/0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7",
+        "https://polygonscan.com/token/0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
+        "https://snowtrace.io/token/0x214db107654ff987ad859f34125307783fc8e387",
+        "https://moonriver.moonscan.io/token/0x6f1d1ee50846fcbc3de91723e61cb68cfa6d0e98",
+        "https://scan.meter.io/address/0x7d016eec9c25232b01f23ef992d98ca97fc2af5a",
+        "https://ftmscan.com/address/0x7d016eec9c25232b01f23ef992d98ca97fc2af5a"
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/MTZu6Hf57d", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "fraxfinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "fraxfinance",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/fraxfinance/frax-solidity"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/13423/thumb/Frax_Shares_icon.png?1679886947",
+      "small": "https://assets.coingecko.com/coins/images/13423/small/Frax_Shares_icon.png?1679886947",
+      "large": "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1679886947"
+    },
+    "country_origin": "KY",
+    "genesis_date": null,
+    "contract_address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+    "sentiment_votes_up_percentage": 60,
+    "sentiment_votes_down_percentage": 40,
+    "watchlist_portfolio_users": 29728,
+    "market_cap_rank": 90,
+    "coingecko_rank": 665,
+    "coingecko_score": 25.054,
+    "developer_score": 0,
+    "community_score": 9.224,
+    "liquidity_score": 41.82,
+    "public_interest_score": 0.005,
+    "market_data": {
+      "current_price": {
+        "usd": 6.51
+      },
+      "total_value_locked": {
+        "usd": 182296084
+      },
+      "mcap_to_tvl_ratio": 2.6,
+      "fdv_to_tvl_ratio": 3.56,
+      "roi": null,
+      "ath": {
+        "usd": 42.8
+      },
+      "ath_change_percentage": {
+        "usd": -84.80656
+      },
+      "ath_date": {
+        "usd": "2022-01-12T15:22:27.465Z"
+      },
+      "atl": {
+        "usd": 1.5
+      },
+      "atl_change_percentage": {
+        "usd": 332.60595
+      },
+      "atl_date": {
+        "usd": "2021-06-25T16:50:51.447Z"
+      },
+      "market_cap": {
+        "usd": 473399373
+      },
+      "market_cap_rank": 90,
+      "fully_diluted_valuation": {
+        "usd": 648743004
+      },
+      "total_volume": {
+        "usd": 32763499
+      },
+      "high_24h": {
+        "usd": 6.55
+      },
+      "low_24h": {
+        "usd": 5.77
+      },
+      "price_change_24h": 0.696398,
+      "price_change_percentage_24h": 11.97731,
+      "price_change_percentage_7d": 10.18245,
+      "price_change_percentage_14d": 21.19306,
+      "price_change_percentage_30d": -0.70454,
+      "price_change_percentage_60d": -14.90637,
+      "price_change_percentage_200d": 20.24798,
+      "price_change_percentage_1y": 35.48397,
+      "market_cap_change_24h": 49395027,
+      "market_cap_change_percentage_24h": 11.64965,
+      "price_change_24h_in_currency": {
+        "usd": 0.696398
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.27428
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 11.97731
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 10.18245
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 21.19306
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -0.70454
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -14.90637
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 20.24798
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 35.48397
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 49395027
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 11.64965
+      },
+      "total_supply": 99707752.7128909,
+      "max_supply": 99707752.7128909,
+      "circulating_supply": 72758530.4758766,
+      "last_updated": "2023-07-03T17:54:37.607Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:54:37.607Z"
+  },
+  {
+    "id": "gitcoin",
+    "symbol": "gtc",
+    "name": "Gitcoin",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+      "near-protocol": "de30da39c46104798bb5aa3fe8b9e0e1f348163f.factory.bridge.near"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "de30da39c46104798bb5aa3fe8b9e0e1f348163f.factory.bridge.near"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Gitcoin is a platform to fund builders looking for meaningful, open source work."
+    },
+    "links": {
+      "homepage": ["https://gitcoin.co/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+        "https://ethplorer.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+        "https://nearblocks.io/token/de30da39c46104798bb5aa3fe8b9e0e1f348163f.factory.bridge.near",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/gitcoin", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "gitcoin",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": "https://www.reddit.com/r/gitcoincommunity",
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929",
+      "small": "https://assets.coingecko.com/coins/images/15810/small/gitcoin.png?1621992929",
+      "large": "https://assets.coingecko.com/coins/images/15810/large/gitcoin.png?1621992929"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 14429,
+    "market_cap_rank": 329,
+    "coingecko_rank": 506,
+    "coingecko_score": 27.47,
+    "developer_score": 0,
+    "community_score": 32.649,
+    "liquidity_score": 37.251,
+    "public_interest_score": 0.04,
+    "market_data": {
+      "current_price": {
+        "usd": 1.19
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 89.62
+      },
+      "ath_change_percentage": {
+        "usd": -98.67512
+      },
+      "ath_date": {
+        "usd": "2021-05-25T15:33:23.602Z"
+      },
+      "atl": {
+        "usd": 0.841165
+      },
+      "atl_change_percentage": {
+        "usd": 41.16357
+      },
+      "atl_date": {
+        "usd": "2023-06-10T04:31:37.518Z"
+      },
+      "market_cap": {
+        "usd": 72303026
+      },
+      "market_cap_rank": 329,
+      "fully_diluted_valuation": {
+        "usd": 118795631
+      },
+      "total_volume": {
+        "usd": 2973733
+      },
+      "high_24h": {
+        "usd": 1.19
+      },
+      "low_24h": {
+        "usd": 1.096
+      },
+      "price_change_24h": 0.08481,
+      "price_change_percentage_24h": 7.68572,
+      "price_change_percentage_7d": 4.21126,
+      "price_change_percentage_14d": 24.51838,
+      "price_change_percentage_30d": -12.63943,
+      "price_change_percentage_60d": -33.38468,
+      "price_change_percentage_200d": -26.31468,
+      "price_change_percentage_1y": -52.88724,
+      "market_cap_change_24h": 5051245,
+      "market_cap_change_percentage_24h": 7.51095,
+      "price_change_24h_in_currency": {
+        "usd": 0.08481
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.62405
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 7.68572
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 4.21126
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 24.51838
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -12.63943
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -33.38468
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -26.31468
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -52.88724
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 5051245
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 7.51095
+      },
+      "total_supply": 100000000,
+      "max_supply": 100000000,
+      "circulating_supply": 60863371.560695864,
+      "last_updated": "2023-07-03T17:54:49.616Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:54:49.616Z"
+  },
+  {
+    "id": "gitcoin-staked-eth-index",
+    "symbol": "gtceth",
+    "name": "Gitcoin Staked ETH Index",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x36c833eed0d376f75d1ff9dfdee260191336065e"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x36c833eed0d376f75d1ff9dfdee260191336065e"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [
+      "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
+    ],
+    "description": {
+      "en": "The Gitcoin Staked ETH Index (gtcETH) is an index token made up of the leading Ethereum liquid staking tokens. In addition to a methodology that encourages decentralization, gtcETH shares a portion of staking rewards with Gitcoin in support of public goods funding."
+    },
+    "links": {
+      "homepage": ["https://indexcoop.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/address/0x36c833eed0d376f75d1ff9dfdee260191336065e",
+        "https://etherscan.io/token/0x36c833eed0d376f75d1ff9dfdee260191336065e",
+        "https://ethplorer.io/address/0x36c833eed0d376f75d1ff9dfdee260191336065e",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["https://www.linkedin.com/company/index-coop/", "", ""],
+      "chat_url": ["https://discord.gg/indexcoop", "https://indexcoop.com/blog", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/IndexCoop/index-protocol"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/29171/thumb/gtcETH-token-logo.png?1677060167",
+      "small": "https://assets.coingecko.com/coins/images/29171/small/gtcETH-token-logo.png?1677060167",
+      "large": "https://assets.coingecko.com/coins/images/29171/large/gtcETH-token-logo.png?1677060167"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x36c833eed0d376f75d1ff9dfdee260191336065e",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 26,
+    "market_cap_rank": 2892,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 2002.58
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 2008.88
+      },
+      "ath_change_percentage": {
+        "usd": -0.31331
+      },
+      "ath_date": {
+        "usd": "2023-07-03T15:42:32.807Z"
+      },
+      "atl": {
+        "usd": 1394.93
+      },
+      "atl_change_percentage": {
+        "usd": 43.56171
+      },
+      "atl_date": {
+        "usd": "2023-03-10T11:49:41.620Z"
+      },
+      "market_cap": {
+        "usd": 147891
+      },
+      "market_cap_rank": 2892,
+      "fully_diluted_valuation": {
+        "usd": 147891
+      },
+      "total_volume": {
+        "usd": 22442
+      },
+      "high_24h": {
+        "usd": 2008.88
+      },
+      "low_24h": {
+        "usd": 1944.73
+      },
+      "price_change_24h": 51.36,
+      "price_change_percentage_24h": 2.63195,
+      "price_change_percentage_7d": 4.40806,
+      "price_change_percentage_14d": 15.47764,
+      "price_change_percentage_30d": 4.30899,
+      "price_change_percentage_60d": 4.53136,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": 3652.01,
+      "market_cap_change_percentage_24h": 2.53192,
+      "price_change_24h_in_currency": {
+        "usd": 51.36
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.03072
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.63195
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 4.40806
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 15.47764
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 4.30899
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 4.53136
+      },
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {
+        "usd": 3652.01
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.53192
+      },
+      "total_supply": 73.85,
+      "max_supply": null,
+      "circulating_supply": 73.85,
+      "last_updated": "2023-07-03T17:30:07.563Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:30:07.563Z"
+  },
+  {
+    "id": "giveth",
+    "symbol": "giv",
+    "name": "Giveth",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x900db999074d9277c5da2a43f252d74366230da0",
+      "xdai": "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x900db999074d9277c5da2a43f252d74366230da0"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "Gnosis Chain Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Giveth is a community focused on Building the Future of Giving using blockchain technology. Our intention is to support and reward the funding of public goods by creating open, transparent and free access to the revolutionary funding opportunities available within the Ethereum ecosystem. Check out our Calendar and Join Page to get more involved."
+    },
+    "links": {
+      "homepage": ["https://giveth.io/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x900db999074d9277c5da2a43f252d74366230da0",
+        "https://ethplorer.io/address/0x900db999074d9277c5da2a43f252d74366230da0",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/Uq2TaXP9bC", "", ""],
+      "announcement_url": ["https://medium.com/giveth", ""],
+      "twitter_screen_name": "Givethio",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "Givethio",
+      "subreddit_url": "https://www.reddit.com/r/giveth/",
+      "repos_url": {
+        "github": ["https://github.com/Giveth/giv-token-contracts"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/21792/thumb/GIVToken_200x200.png?1640055088",
+      "small": "https://assets.coingecko.com/coins/images/21792/small/GIVToken_200x200.png?1640055088",
+      "large": "https://assets.coingecko.com/coins/images/21792/large/GIVToken_200x200.png?1640055088"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x900db999074d9277c5da2a43f252d74366230da0",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 341,
+    "market_cap_rank": 1802,
+    "coingecko_rank": 465,
+    "coingecko_score": 28.383,
+    "developer_score": 48.304,
+    "community_score": 23.557,
+    "liquidity_score": 1,
+    "public_interest_score": 0.004,
+    "market_data": {
+      "current_price": {
+        "usd": 0.01014112
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1.017
+      },
+      "ath_change_percentage": {
+        "usd": -99.00326
+      },
+      "ath_date": {
+        "usd": "2021-12-28T07:33:54.071Z"
+      },
+      "atl": {
+        "usd": 0.00367537
+      },
+      "atl_change_percentage": {
+        "usd": 175.7303
+      },
+      "atl_date": {
+        "usd": "2022-12-17T10:22:58.350Z"
+      },
+      "market_cap": {
+        "usd": 1470439
+      },
+      "market_cap_rank": 1802,
+      "fully_diluted_valuation": {
+        "usd": 10137249
+      },
+      "total_volume": {
+        "usd": 499.04
+      },
+      "high_24h": {
+        "usd": 0.01031039
+      },
+      "low_24h": {
+        "usd": 0.00993501
+      },
+      "price_change_24h": 0.00000476,
+      "price_change_percentage_24h": 0.047,
+      "price_change_percentage_7d": -0.72226,
+      "price_change_percentage_14d": 8.12263,
+      "price_change_percentage_30d": -13.85475,
+      "price_change_percentage_60d": -17.19385,
+      "price_change_percentage_200d": -48.65861,
+      "price_change_percentage_1y": -78.86315,
+      "market_cap_change_24h": 57561,
+      "market_cap_change_percentage_24h": 4.07405,
+      "price_change_24h_in_currency": {
+        "usd": 0.00000476
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.41569
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.047
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.72226
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 8.12263
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -13.85475
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -17.19385
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -48.65861
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -78.86315
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 57561
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.07405
+      },
+      "total_supply": 1000000000,
+      "max_supply": 1000000000,
+      "circulating_supply": 145053055.278473,
+      "last_updated": "2023-07-03T17:53:12.973Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:53:12.973Z"
+  },
+  {
+    "id": "hex",
+    "symbol": "hex",
+    "name": "HEX",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
+      "polygon-pos": "0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c",
+      "harmony-shard-0": "0xf26d8c787e66254ee8b7a500073da8fb1ab1992d"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 8,
+        "contract_address": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39"
+      },
+      "polygon-pos": {
+        "decimal_place": 8,
+        "contract_address": "0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 8,
+        "contract_address": "0xf26d8c787e66254ee8b7a500073da8fb1ab1992d"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": "Ethash",
+    "categories": [
+      "PulseChain Ecosystem",
+      "Harmony Ecosystem",
+      "Polygon Ecosystem",
+      "Ethereum Ecosystem",
+      "Cryptocurrency"
+    ],
+    "public_notice": "NOTE: Due to the price difference on PulseChain, HEX (PulseChain) is tracked separately to avoid confusion. Kindly visit the token page <a href=https://www.coingecko.com/en/coins/hex-pulsechain>here</a>.",
+    "additional_notices": [],
+    "description": {
+      "en": "Launched on December 2, 2019 by Richard Heart and team, HEX is the first certificate of deposit on the blockchain, essentially time deposits that gain interest, HEX is an ERC20 Token that runs over the Ethereum network\r\n"
+    },
+    "links": {
+      "homepage": ["https://hex.com", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
+        "https://ethplorer.io/address/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
+        "https://polygonscan.com/token/0x23d29d30e35c5e8d321e1dc9a8a61bfd846d4c5c",
+        "https://scan.pulsechain.com/token/0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discordapp.com/invite/CA8jVuF", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "HEXcrypto",
+      "facebook_username": "HEXcrypto",
+      "bitcointalk_thread_identifier": 4523610,
+      "telegram_channel_identifier": "HEXcrypto",
+      "subreddit_url": "https://www.reddit.com/r/HEXcrypto/",
+      "repos_url": {
+        "github": ["https://github.com/HexCommunity"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/10103/thumb/HEX-logo.png?1575942673",
+      "small": "https://assets.coingecko.com/coins/images/10103/small/HEX-logo.png?1575942673",
+      "large": "https://assets.coingecko.com/coins/images/10103/large/HEX-logo.png?1575942673"
+    },
+    "country_origin": "US",
+    "genesis_date": null,
+    "contract_address": "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
+    "sentiment_votes_up_percentage": 55.77,
+    "sentiment_votes_down_percentage": 44.23,
+    "watchlist_portfolio_users": 53253,
+    "market_cap_rank": null,
+    "coingecko_rank": 1555,
+    "coingecko_score": 17.405,
+    "developer_score": 0,
+    "community_score": 40.488,
+    "liquidity_score": 42.481,
+    "public_interest_score": 0.029,
+    "market_data": {
+      "current_price": {
+        "usd": 0.00798453
+      },
+      "total_value_locked": {
+        "usd": 0
+      },
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 0.51083
+      },
+      "ath_change_percentage": {
+        "usd": -98.44471
+      },
+      "ath_date": {
+        "usd": "2021-09-19T06:39:56.189Z"
+      },
+      "atl": {
+        "usd": 0.00005645
+      },
+      "atl_change_percentage": {
+        "usd": 13974.77758
+      },
+      "atl_date": {
+        "usd": "2020-01-05T06:29:30.998Z"
+      },
+      "market_cap": {
+        "usd": 0
+      },
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {
+        "usd": 4676749393
+      },
+      "total_volume": {
+        "usd": 1173601
+      },
+      "high_24h": {
+        "usd": 0.00794723
+      },
+      "low_24h": {
+        "usd": 0.00721278
+      },
+      "price_change_24h": 0.00020617,
+      "price_change_percentage_24h": 2.65058,
+      "price_change_percentage_7d": -2.48566,
+      "price_change_percentage_14d": -9.92814,
+      "price_change_percentage_30d": -42.22303,
+      "price_change_percentage_60d": -86.9015,
+      "price_change_percentage_200d": -69.65571,
+      "price_change_percentage_1y": -76.5937,
+      "market_cap_change_24h": 0,
+      "market_cap_change_percentage_24h": 0,
+      "price_change_24h_in_currency": {
+        "usd": 0.00020617
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 1.93808
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.65058
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -2.48566
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -9.92814
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -42.22303
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -86.9015
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -69.65571
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -76.5937
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 0
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 0
+      },
+      "total_supply": 588854801578.477,
+      "max_supply": null,
+      "circulating_supply": 0,
+      "last_updated": "2023-07-03T17:54:23.818Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 21315,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:54:23.818Z"
+  },
+  {
+    "id": "honey",
+    "symbol": "hny",
+    "name": "Honey",
+    "asset_platform_id": "xdai",
+    "platforms": {
+      "xdai": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
+      "ethereum": "0xc3589f56b6869824804a5ea29f2c9886af1b0fce"
+    },
+    "detail_platforms": {
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9"
+      },
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xc3589f56b6869824804a5ea29f2c9886af1b0fce"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "Gnosis Chain Ecosystem", "Decentralized Exchange (DEX)"],
+    "public_notice": null,
+    "additional_notices": [
+      "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
+    ],
+    "description": {
+      "en": "1Hive is a DAO that issues and distributes a digital currency called Honey.\r\nHoney holders stake on proposals using Conviction Voting to determine how issuance is distributed. By supporting proposals which increase the value of Honey, a positive feedback loop drives growth and sustainability.\r\n\r\nConviction Voting allows everyone to participate and shape the direction of 1Hive, while preventing anyone from taking control or ownership."
+    },
+    "links": {
+      "homepage": ["https://1hive.org/", "", ""],
+      "blockchain_site": [
+        "https://blockscout.com/poa/xdai/tokens/0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9",
+        "https://etherscan.io/token/0xc3589f56b6869824804a5ea29f2c9886af1b0fce",
+        "https://ethplorer.io/address/0xc3589f56b6869824804a5ea29f2c9886af1b0fce",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/xTZjbRjc8t", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "Honeyswap",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "honeyswapdex",
+      "subreddit_url": "https://www.reddit.com/r/hny",
+      "repos_url": {
+        "github": ["https://github.com/1Hive"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/12895/thumb/hnys.png?1614100588",
+      "small": "https://assets.coingecko.com/coins/images/12895/small/hnys.png?1614100588",
+      "large": "https://assets.coingecko.com/coins/images/12895/large/hnys.png?1614100588"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x71850b7e9ee3f13ab46d67167341e4bdc905eef9",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 2729,
+    "market_cap_rank": null,
+    "coingecko_rank": 3959,
+    "coingecko_score": 5.748,
+    "developer_score": 0,
+    "community_score": 25.216,
+    "liquidity_score": 1,
+    "public_interest_score": 0.001,
+    "market_data": {
+      "current_price": {
+        "usd": 9.71
+      },
+      "total_value_locked": {
+        "usd": 5829643
+      },
+      "mcap_to_tvl_ratio": 0,
+      "fdv_to_tvl_ratio": 0.06,
+      "roi": null,
+      "ath": {
+        "usd": 2187.59
+      },
+      "ath_change_percentage": {
+        "usd": -99.55633
+      },
+      "ath_date": {
+        "usd": "2021-09-06T05:05:04.933Z"
+      },
+      "atl": {
+        "usd": 0.185133
+      },
+      "atl_change_percentage": {
+        "usd": 5142.59525
+      },
+      "atl_date": {
+        "usd": "2021-09-13T18:45:06.781Z"
+      },
+      "market_cap": {
+        "usd": 0
+      },
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {
+        "usd": 354301
+      },
+      "total_volume": {
+        "usd": 774.88
+      },
+      "high_24h": {
+        "usd": 9.9
+      },
+      "low_24h": {
+        "usd": 9.55
+      },
+      "price_change_24h": 0.088557,
+      "price_change_percentage_24h": 0.92005,
+      "price_change_percentage_7d": 0.78406,
+      "price_change_percentage_14d": 8.55806,
+      "price_change_percentage_30d": -4.15251,
+      "price_change_percentage_60d": -23.71692,
+      "price_change_percentage_200d": -32.12281,
+      "price_change_percentage_1y": -72.93039,
+      "market_cap_change_24h": 0,
+      "market_cap_change_percentage_24h": 0,
+      "price_change_24h_in_currency": {
+        "usd": 0.088557
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.50658
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.92005
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 0.78406
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 8.55806
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -4.15251
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -23.71692
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -32.12281
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -72.93039
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 0
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 0
+      },
+      "total_supply": 36489.9752090467,
+      "max_supply": null,
+      "circulating_supply": 0,
+      "last_updated": "2023-07-03T17:53:01.394Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 105341,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:53:01.394Z"
+  },
+  {
+    "id": "hop-protocol",
+    "symbol": "hop",
+    "name": "Hop Protocol",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "polygon-pos": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "optimistic-ethereum": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "arbitrum-one": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+      "xdai": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Polygon Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Arbitrum Ecosystem",
+      "Ethereum Ecosystem",
+      "Optimism Ecosystem"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Hop is a protocol for sending tokens across rollups and their shared layer-1 network in a quick and trustless manner."
+    },
+    "links": {
+      "homepage": ["https://app.hop.exchange/", "https://hop.mirror.xyz/", "https://hop.eth.link/"],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+        "https://ethplorer.io/address/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+        "https://optimistic.etherscan.io/token/0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
+        "https://arbiscan.io/token/0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+        "https://polygonscan.com/token/0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/PwCF88emV4", "", ""],
+      "announcement_url": ["https://medium.com/hop-protocol", ""],
+      "twitter_screen_name": "HopProtocol",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/hop-protocol"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/25445/thumb/hop.png?1665541677",
+      "small": "https://assets.coingecko.com/coins/images/25445/small/hop.png?1665541677",
+      "large": "https://assets.coingecko.com/coins/images/25445/large/hop.png?1665541677"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 5589,
+    "market_cap_rank": 1216,
+    "coingecko_rank": 1461,
+    "coingecko_score": 18.001,
+    "developer_score": 0,
+    "community_score": 9.623,
+    "liquidity_score": 21.024,
+    "public_interest_score": 0.014,
+    "market_data": {
+      "current_price": {
+        "usd": 0.061597
+      },
+      "total_value_locked": {
+        "usd": 72282593
+      },
+      "mcap_to_tvl_ratio": 0.06,
+      "fdv_to_tvl_ratio": 0.85,
+      "roi": null,
+      "ath": {
+        "usd": 0.297217
+      },
+      "ath_change_percentage": {
+        "usd": -79.31747
+      },
+      "ath_date": {
+        "usd": "2023-03-20T16:14:36.301Z"
+      },
+      "atl": {
+        "usd": 0.051576
+      },
+      "atl_change_percentage": {
+        "usd": 19.18737
+      },
+      "atl_date": {
+        "usd": "2023-06-16T07:54:53.341Z"
+      },
+      "market_cap": {
+        "usd": 4634340
+      },
+      "market_cap_rank": 1216,
+      "fully_diluted_valuation": {
+        "usd": 61608446
+      },
+      "total_volume": {
+        "usd": 101409
+      },
+      "high_24h": {
+        "usd": 0.062244
+      },
+      "low_24h": {
+        "usd": 0.060604
+      },
+      "price_change_24h": 0.00005194,
+      "price_change_percentage_24h": 0.0844,
+      "price_change_percentage_7d": -4.85179,
+      "price_change_percentage_14d": -0.71031,
+      "price_change_percentage_30d": -21.79543,
+      "price_change_percentage_60d": -48.70719,
+      "price_change_percentage_200d": -26.28654,
+      "price_change_percentage_1y": -34.97593,
+      "market_cap_change_24h": 58042,
+      "market_cap_change_percentage_24h": 1.26831,
+      "price_change_24h_in_currency": {
+        "usd": 0.00005194
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.48295
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.0844
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -4.85179
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -0.71031
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -21.79543
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -48.70719
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -26.28654
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -34.97593
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 58042
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 1.26831
+      },
+      "total_supply": 1000000000,
+      "max_supply": 1000000000,
+      "circulating_supply": 75222483.07101855,
+      "last_updated": "2023-07-03T17:55:30.301Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:55:30.301Z"
+  },
+  {
+    "id": "ice-token",
+    "symbol": "ice",
+    "name": "Popsicle Finance",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xf16e81dce15b08f326220742020379b855b87df9",
+      "fantom": "0xf16e81dce15b08f326220742020379b855b87df9",
+      "binance-smart-chain": "0xf16e81dce15b08f326220742020379b855b87df9",
+      "polygon-pos": "0x4e1581f01046efdd7a1a2cdb0f82cdd7f71f2e59"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x4e1581f01046efdd7a1a2cdb0f82cdd7f71f2e59"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Ethereum Ecosystem",
+      "Polygon Ecosystem",
+      "BNB Chain Ecosystem",
+      "Fantom Ecosystem",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "A next-gen cross-chain yield enhancement platform focusing on Automated Market-Making (AMM) Liquidity Providers (LP)"
+    },
+    "links": {
+      "homepage": ["https://popsicle.finance/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xf16e81dce15b08f326220742020379b855b87df9",
+        "https://ethplorer.io/address/0xf16e81dce15b08f326220742020379b855b87df9",
+        "https://bscscan.com/token/0xf16e81dce15b08f326220742020379b855b87df9",
+        "https://polygonscan.com/token/0x4e1581f01046efdd7a1a2cdb0f82cdd7f71f2e59",
+        "https://ftmscan.com/token/0xf16e81dce15b08f326220742020379b855b87df9",
+        "https://scan.meter.io/address/0xf16e81dce15b08f326220742020379b855b87df9",
+        "https://ftmscan.com/address/0xf16e81dce15b08f326220742020379b855b87df9",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/GDwhREgj5E", "", ""],
+      "announcement_url": ["https://popsiclefinance.medium.com/", ""],
+      "twitter_screen_name": "PopsicleFinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/Popsicle-Finance/"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14586/thumb/ice.png?1617188825",
+      "small": "https://assets.coingecko.com/coins/images/14586/small/ice.png?1617188825",
+      "large": "https://assets.coingecko.com/coins/images/14586/large/ice.png?1617188825"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xf16e81dce15b08f326220742020379b855b87df9",
+    "sentiment_votes_up_percentage": 50,
+    "sentiment_votes_down_percentage": 50,
+    "watchlist_portfolio_users": 20491,
+    "market_cap_rank": 639,
+    "coingecko_rank": 1796,
+    "coingecko_score": 16.02,
+    "developer_score": 0,
+    "community_score": 9.457,
+    "liquidity_score": 13.385,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 1.48
+      },
+      "total_value_locked": {
+        "usd": 1161554
+      },
+      "mcap_to_tvl_ratio": 19.88,
+      "fdv_to_tvl_ratio": 30.7,
+      "roi": null,
+      "ath": {
+        "usd": 66.04
+      },
+      "ath_change_percentage": {
+        "usd": -97.7607
+      },
+      "ath_date": {
+        "usd": "2021-11-06T18:39:46.590Z"
+      },
+      "atl": {
+        "usd": 0.093364
+      },
+      "atl_change_percentage": {
+        "usd": 1484.02496
+      },
+      "atl_date": {
+        "usd": "2022-12-19T20:32:12.193Z"
+      },
+      "market_cap": {
+        "usd": 23089506
+      },
+      "market_cap_rank": 639,
+      "fully_diluted_valuation": {
+        "usd": 35656063
+      },
+      "total_volume": {
+        "usd": 449431
+      },
+      "high_24h": {
+        "usd": 1.54
+      },
+      "low_24h": {
+        "usd": 1.28
+      },
+      "price_change_24h": 0.179917,
+      "price_change_percentage_24h": 13.88792,
+      "price_change_percentage_7d": 24.85921,
+      "price_change_percentage_14d": 74.61963,
+      "price_change_percentage_30d": 16.28826,
+      "price_change_percentage_60d": 25.76726,
+      "price_change_percentage_200d": 1017.90026,
+      "price_change_percentage_1y": 438.228,
+      "market_cap_change_24h": 2751568,
+      "market_cap_change_percentage_24h": 13.52924,
+      "price_change_24h_in_currency": {
+        "usd": 0.179917
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.22732
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 13.88792
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 24.85921
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 74.61963
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 16.28826
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 25.76726
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 1017.90026
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 438.228
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 2751568
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 13.52924
+      },
+      "total_supply": 24157859,
+      "max_supply": null,
+      "circulating_supply": 15643707.9084763,
+      "last_updated": "2023-07-03T17:56:17.101Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:56:17.101Z"
+  },
+  {
+    "id": "liquity",
+    "symbol": "lqty",
+    "name": "Liquity",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+      "arbitrum-one": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Arbitrum Ecosystem", "Ethereum Ecosystem", "Lending/Borrowing", "Decentralized Finance (DeFi)"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "LQTY is a token that captures the fee revenue generated by the Liquity Protocol via staking. Liquity is a decentralized borrowing protocol that allows you to draw 0% interest loans against Ether used as collateral. Loans are paid out in LUSD and need to maintain a minimum collateral ratio of only 110%.\r\n\r\nIn addition to the collateral, the loans are secured by a Stability Pool containing LUSD and by fellow borrowers collectively acting as guarantors of last resort. \r\n\r\nLiquity as a protocol is non-custodial, immutable, and governance-free."
+    },
+    "links": {
+      "homepage": ["https://www.liquity.org/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+        "https://ethplorer.io/address/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+        "https://arbiscan.io/token/0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+        "https://arbiscan.io/token/0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/2up5U32", "", ""],
+      "announcement_url": ["https://medium.com/liquity", ""],
+      "twitter_screen_name": "LiquityProtocol",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": "https://www.reddit.com\\/r/Liquity/",
+      "repos_url": {
+        "github": ["https://github.com/liquity/dev"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180",
+      "small": "https://assets.coingecko.com/coins/images/14665/small/200-lqty-icon.png?1617631180",
+      "large": "https://assets.coingecko.com/coins/images/14665/large/200-lqty-icon.png?1617631180"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+    "sentiment_votes_up_percentage": 80,
+    "sentiment_votes_down_percentage": 20,
+    "watchlist_portfolio_users": 14805,
+    "market_cap_rank": 280,
+    "coingecko_rank": 679,
+    "coingecko_score": 24.861,
+    "developer_score": 0,
+    "community_score": 27.187,
+    "liquidity_score": 27.034,
+    "public_interest_score": 0.003,
+    "market_data": {
+      "current_price": {
+        "usd": 0.98504
+      },
+      "total_value_locked": {
+        "usd": 775161801
+      },
+      "mcap_to_tvl_ratio": 0.12,
+      "fdv_to_tvl_ratio": 0.13,
+      "roi": null,
+      "ath": {
+        "usd": 146.94
+      },
+      "ath_change_percentage": {
+        "usd": -99.32998
+      },
+      "ath_date": {
+        "usd": "2021-04-05T21:48:37.754Z"
+      },
+      "atl": {
+        "usd": 0.54399
+      },
+      "atl_change_percentage": {
+        "usd": 80.98468
+      },
+      "atl_date": {
+        "usd": "2022-11-14T07:05:51.360Z"
+      },
+      "market_cap": {
+        "usd": 91199981
+      },
+      "market_cap_rank": 280,
+      "fully_diluted_valuation": {
+        "usd": 98415553
+      },
+      "total_volume": {
+        "usd": 14229840
+      },
+      "high_24h": {
+        "usd": 1.015
+      },
+      "low_24h": {
+        "usd": 0.931944
+      },
+      "price_change_24h": 0.052606,
+      "price_change_percentage_24h": 5.64178,
+      "price_change_percentage_7d": 4.92487,
+      "price_change_percentage_14d": 19.44853,
+      "price_change_percentage_30d": -21.90077,
+      "price_change_percentage_60d": -41.54452,
+      "price_change_percentage_200d": 63.049,
+      "price_change_percentage_1y": 7.10066,
+      "market_cap_change_24h": 4394365,
+      "market_cap_change_percentage_24h": 5.06231,
+      "price_change_24h_in_currency": {
+        "usd": 0.052606
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.72226
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 5.64178
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 4.92487
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 19.44853
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -21.90077
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -41.54452
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 63.049
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 7.10066
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 4394365
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 5.06231
+      },
+      "total_supply": 100000000,
+      "max_supply": 100000000,
+      "circulating_supply": 92668260.2497627,
+      "last_updated": "2023-07-03T17:57:45.841Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:57:45.841Z"
+  },
+  {
+    "id": "liquity-usd",
+    "symbol": "lusd",
+    "name": "Liquity USD",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+      "arbitrum-one": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
+      "polygon-pos": "0x23001f892c0c82b79303edc9b9033cd190bb21c7",
+      "optimistic-ethereum": "0xc40f949f8a4e094d1b49a23ea9241d289b7b2819"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x23001f892c0c82b79303edc9b9033cd190bb21c7"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xc40f949f8a4e094d1b49a23ea9241d289b7b2819"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Arbitrum Ecosystem",
+      "Optimism Ecosystem",
+      "Polygon Ecosystem",
+      "Ethereum Ecosystem",
+      "USD Stablecoin",
+      "Stablecoins",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "LUSD is a fully redeemable USD-pegged stablecoin issued by the Liquity Protocol. Liquity is a decentralized borrowing protocol that allows you to draw 0% interest loans against Ether used as collateral. Loans are paid out in LUSD and need to maintain a minimum collateral ratio of only 110%.\r\n\r\nIn addition to the collateral, the loans are secured by a Stability Pool containing LUSD and by fellow borrowers collectively acting as guarantors of last resort. \r\n\r\nLiquity as a protocol is non-custodial, immutable, and governance-free."
+    },
+    "links": {
+      "homepage": ["https://www.liquity.org/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "https://ethplorer.io/address/0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "https://polygonscan.com/token/0x23001f892c0c82b79303edc9b9033cd190bb21c7",
+        "https://optimistic.etherscan.io/token/0xc40f949f8a4e094d1b49a23ea9241d289b7b2819",
+        "https://arbiscan.io/token/0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "https://discord.gg/2up5U32", ""],
+      "announcement_url": ["https://medium.com/liquity", ""],
+      "twitter_screen_name": "LiquityProtocol",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": "https://www.reddit.com/r/Liquity/",
+      "repos_url": {
+        "github": ["https://github.com/liquity/dev"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+      "small": "https://assets.coingecko.com/coins/images/14666/small/Group_3.png?1617631327",
+      "large": "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1617631327"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 3152,
+    "market_cap_rank": 125,
+    "coingecko_rank": 490,
+    "coingecko_score": 27.776,
+    "developer_score": 0,
+    "community_score": 27.183,
+    "liquidity_score": 37.699,
+    "public_interest_score": 0.003,
+    "market_data": {
+      "current_price": {
+        "usd": 1.002
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1.16
+      },
+      "ath_change_percentage": {
+        "usd": -13.51861
+      },
+      "ath_date": {
+        "usd": "2021-04-05T14:47:52.665Z"
+      },
+      "atl": {
+        "usd": 0.896722
+      },
+      "atl_change_percentage": {
+        "usd": 11.71078
+      },
+      "atl_date": {
+        "usd": "2022-01-27T09:42:06.510Z"
+      },
+      "market_cap": {
+        "usd": 283401679
+      },
+      "market_cap_rank": 125,
+      "fully_diluted_valuation": {
+        "usd": 283414678
+      },
+      "total_volume": {
+        "usd": 4122517
+      },
+      "high_24h": {
+        "usd": 1.007
+      },
+      "low_24h": {
+        "usd": 0.997643
+      },
+      "price_change_24h": -0.00090177710424,
+      "price_change_percentage_24h": -0.08995,
+      "price_change_percentage_7d": -0.16632,
+      "price_change_percentage_14d": -0.60404,
+      "price_change_percentage_30d": -0.41747,
+      "price_change_percentage_60d": -1.50703,
+      "price_change_percentage_200d": -2.01607,
+      "price_change_percentage_1y": -1.56195,
+      "market_cap_change_24h": -539926.289427,
+      "market_cap_change_percentage_24h": -0.19015,
+      "price_change_24h_in_currency": {
+        "usd": -0.000901777104240997
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.13922
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": -0.08995
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.16632
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -0.60404
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -0.41747
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -1.50703
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -2.01607
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -1.56195
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": -539926.2894271016
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -0.19015
+      },
+      "total_supply": 282772276.909511,
+      "max_supply": null,
+      "circulating_supply": 282759306.907073,
+      "last_updated": "2023-07-03T17:58:22.034Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:58:22.034Z"
+  },
+  {
+    "id": "magic-internet-money",
+    "symbol": "mim",
+    "name": "Magic Internet Money",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
+      "optimistic-ethereum": "0xb153fb3d196a8eb25522705560ac152eeec57901",
+      "binance-smart-chain": "0xfe19f0b51438fd612f6fd59c1dbb3ea319f433ba",
+      "avalanche": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "moonriver": "0x0cae51e1032e8461f4806e26332c030e34de3adb",
+      "arbitrum-one": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+      "fantom": "0x82f0b8b456c1a451378467398982d4834b6829c1",
+      "polygon-pos": "0x49a0400587a7f65072c87c4910449fdcc5c47242"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3"
+      },
+      "optimistic-ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xb153fb3d196a8eb25522705560ac152eeec57901"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xfe19f0b51438fd612f6fd59c1dbb3ea319f433ba"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x130966628846bfd36ff31a822705796e8cb8c18d"
+      },
+      "moonriver": {
+        "decimal_place": 18,
+        "contract_address": "0x0cae51e1032e8461f4806e26332c030e34de3adb"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0x82f0b8b456c1a451378467398982d4834b6829c1"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x49a0400587a7f65072c87c4910449fdcc5c47242"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Optimism Ecosystem",
+      "USD Stablecoin",
+      "BNB Chain Ecosystem",
+      "Ethereum Ecosystem",
+      "Fantom Ecosystem",
+      "Arbitrum Ecosystem",
+      "Polygon Ecosystem",
+      "Moonriver Ecosystem",
+      "Avalanche Ecosystem",
+      "Stablecoins",
+      "Decentralized Finance (DeFi)"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Abracadabra.money is a lending platform that allows users to mint the Stablecoin MIM using interest bearing tokens as collaterals!"
+    },
+    "links": {
+      "homepage": ["https://abracadabra.money/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
+        "https://ethplorer.io/address/0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
+        "https://arbiscan.io/token/0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
+        "https://avascan.info/blockchain/c/address/0x130966628846bfd36ff31a822705796e8cb8c18d",
+        "https://snowtrace.io/token/0x130966628846bfd36ff31a822705796e8cb8c18d",
+        "https://moonriver.moonscan.io/token/0x0cae51e1032e8461f4806e26332c030e34de3adb",
+        "https://polygonscan.com/token/0x49a0400587a7f65072c87c4910449fdcc5c47242",
+        "https://ftmscan.com/token/0x82f0b8b456c1a451378467398982d4834b6829c1",
+        "https://scan.meter.io/address/0x82f0b8b456c1a451378467398982d4834b6829c1",
+        "https://ftmscan.com/address/0x82f0b8b456c1a451378467398982d4834b6829c1"
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/wcsUNxYrFM", "", ""],
+      "announcement_url": ["https://abracadabramoney.medium.com/", ""],
+      "twitter_screen_name": "MIM_Spell",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "abracadabramoney",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/Abracadabra-money/magic-internet-money"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612",
+      "small": "https://assets.coingecko.com/coins/images/16786/small/mimlogopng.png?1624979612",
+      "large": "https://assets.coingecko.com/coins/images/16786/large/mimlogopng.png?1624979612"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 11863,
+    "market_cap_rank": 290,
+    "coingecko_rank": 820,
+    "coingecko_score": 23.04,
+    "developer_score": 0,
+    "community_score": 9.947,
+    "liquidity_score": 32.321,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 0.994706
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1.041
+      },
+      "ath_change_percentage": {
+        "usd": -4.47416
+      },
+      "ath_date": {
+        "usd": "2021-10-06T13:25:17.751Z"
+      },
+      "atl": {
+        "usd": 0.876409
+      },
+      "atl_change_percentage": {
+        "usd": 13.47172
+      },
+      "atl_date": {
+        "usd": "2023-03-11T08:02:51.714Z"
+      },
+      "market_cap": {
+        "usd": 86398928
+      },
+      "market_cap_rank": 290,
+      "fully_diluted_valuation": {
+        "usd": 134106796
+      },
+      "total_volume": {
+        "usd": 4207564
+      },
+      "high_24h": {
+        "usd": 1.003
+      },
+      "low_24h": {
+        "usd": 0.990613
+      },
+      "price_change_24h": -0.001265578348201,
+      "price_change_percentage_24h": -0.12707,
+      "price_change_percentage_7d": -0.59372,
+      "price_change_percentage_14d": -0.49908,
+      "price_change_percentage_30d": -0.70981,
+      "price_change_percentage_60d": -0.57793,
+      "price_change_percentage_200d": -0.50085,
+      "price_change_percentage_1y": 0.11558,
+      "market_cap_change_24h": 57512,
+      "market_cap_change_percentage_24h": 0.06661,
+      "price_change_24h_in_currency": {
+        "usd": -0.001265578348200291
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.15939
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": -0.12707
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.59372
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -0.49908
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -0.70981
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -0.57793
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -0.50085
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 0.11558
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 57512
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 0.06661
+      },
+      "total_supply": 134730988.524743,
+      "max_supply": null,
+      "circulating_supply": 86801066.7831391,
+      "last_updated": "2023-07-03T17:58:40.024Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:58:40.024Z"
+  },
+  {
+    "id": "manifold-finance",
+    "symbol": "fold",
+    "name": "Manifold Finance",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "MEV Protection"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Manifold Finance provides solutions encompassing the middleware market for decentralized finance applications and protocols for both scaling and usability purposes. Part of our mission is helping scale the Ethereum ecosystem, which is where the idea of ‘middleware strategies’ comes into play. Our solutions can be thought of as an ‘APY strategy’ that you might find with something like Yearn Finance, except instead of providing capital (e.g. through depositing into a strategy with Yearn), we create applications that provide services that generate revenue (a prime example being YCabal)."
+    },
+    "links": {
+      "homepage": ["https://www.manifoldfinance.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
+        "https://ethplorer.io/address/0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "", ""],
+      "announcement_url": ["https://medium.com/manifoldfinance", ""],
+      "twitter_screen_name": "foldfinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "manifoldfinance",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/manifoldfinance"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/15928/thumb/Manifold.png?1622439811",
+      "small": "https://assets.coingecko.com/coins/images/15928/small/Manifold.png?1622439811",
+      "large": "https://assets.coingecko.com/coins/images/15928/large/Manifold.png?1622439811"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 5539,
+    "market_cap_rank": 636,
+    "coingecko_rank": 824,
+    "coingecko_score": 22.954,
+    "developer_score": 0,
+    "community_score": 7.985,
+    "liquidity_score": 36.814,
+    "public_interest_score": 0.002,
+    "market_data": {
+      "current_price": {
+        "usd": 13.91
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 103.27
+      },
+      "ath_change_percentage": {
+        "usd": -86.52577
+      },
+      "ath_date": {
+        "usd": "2022-09-15T08:04:06.379Z"
+      },
+      "atl": {
+        "usd": 3.83
+      },
+      "atl_change_percentage": {
+        "usd": 263.7219
+      },
+      "atl_date": {
+        "usd": "2021-07-21T01:29:39.734Z"
+      },
+      "market_cap": {
+        "usd": 23154820
+      },
+      "market_cap_rank": 636,
+      "fully_diluted_valuation": {
+        "usd": 27816977
+      },
+      "total_volume": {
+        "usd": 38795
+      },
+      "high_24h": {
+        "usd": 15.44
+      },
+      "low_24h": {
+        "usd": 13.35
+      },
+      "price_change_24h": 0.489505,
+      "price_change_percentage_24h": 3.6461,
+      "price_change_percentage_7d": -1.15652,
+      "price_change_percentage_14d": -8.03018,
+      "price_change_percentage_30d": -7.76039,
+      "price_change_percentage_60d": -27.3151,
+      "price_change_percentage_200d": 6.94777,
+      "price_change_percentage_1y": 64.01767,
+      "market_cap_change_24h": 771479,
+      "market_cap_change_percentage_24h": 3.44666,
+      "price_change_24h_in_currency": {
+        "usd": 0.489505
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.16385
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 3.6461
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -1.15652
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -8.03018
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -7.76039
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -27.3151
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 6.94777
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 64.01767
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 771479
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 3.44666
+      },
+      "total_supply": 2000000,
+      "max_supply": 2000000,
+      "circulating_supply": 1664797.7597608927,
+      "last_updated": "2023-07-03T17:57:36.953Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:57:36.953Z"
+  },
+  {
+    "id": "matic-network",
+    "symbol": "matic",
+    "name": "Polygon",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+      "polygon-pos": "0x0000000000000000000000000000000000001010",
+      "harmony-shard-0": "0x301259f392b551ca8c592c9f676fcd2f9a0a84c5",
+      "binance-smart-chain": "0xcc42724c6683b7e57334c4e856f4c9965ed682bd",
+      "moonriver": "0x682f81e57eaa716504090c3ecba8595fb54561d8",
+      "sora": "0x009134d5c7b7fda8863985531f456f89bef5fbd76684a8acdb737b3e451d0877",
+      "moonbeam": "0x3405a1bd46b85c5c029483fbecf2f3e611026e45",
+      "energi": "0x98997e1651919faeacee7b96afbb3dfd96cb6036"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x0000000000000000000000000000000000001010"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0x301259f392b551ca8c592c9f676fcd2f9a0a84c5"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0xcc42724c6683b7e57334c4e856f4c9965ed682bd"
+      },
+      "moonriver": {
+        "decimal_place": 18,
+        "contract_address": "0x682f81e57eaa716504090c3ecba8595fb54561d8"
+      },
+      "sora": {
+        "decimal_place": 18,
+        "contract_address": "0x009134d5c7b7fda8863985531f456f89bef5fbd76684a8acdb737b3e451d0877"
+      },
+      "moonbeam": {
+        "decimal_place": 18,
+        "contract_address": "0x3405a1bd46b85c5c029483fbecf2f3e611026e45"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0x98997e1651919faeacee7b96afbb3dfd96cb6036"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Zero Knowledge (ZK)",
+      "Layer 2 (L2)",
+      "Harmony Ecosystem",
+      "Ethereum Ecosystem",
+      "Moonbeam Ecosystem",
+      "Moonriver Ecosystem",
+      "BNB Chain Ecosystem",
+      "Smart Contract Platform",
+      "Polygon Ecosystem"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Polygon (Previously Matic Network) is the first well-structured, easy-to-use platform for Ethereum scaling and infrastructure development. Its core component is Polygon SDK, a modular, flexible framework that supports building multiple types of applications.\r\n\r\nUsing Polygon, one can create Optimistic Rollup chains, ZK Rollup chains, stand alone chains or any other kind of infra required by the developer. \r\n\r\nPolygon effectively transforms Ethereum into a full-fledged multi-chain system (aka Internet of Blockchains). This multi-chain system is akin to other ones such as Polkadot, Cosmos, Avalanche etc with the advantages of Ethereum’s security, vibrant ecosystem and openness.\r\n\r\nNothing will change for the existing ecosystem built on the Plasma-POS chain. With Polygon, new features are being built around the existing proven technology to expand the ability to cater to diverse needs from the developer ecosystem. Polygon will continue to develop the core technology so that it can scale to a larger ecosystem. \r\n\r\nThe $MATIC token will continue to exist and will play an increasingly important role, securing the system and enabling governance."
+    },
+    "links": {
+      "homepage": ["https://polygon.technology/", "https://blog.polygon.technology/", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+        "https://ethplorer.io/address/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+        "https://polygonscan.com/token/0x0000000000000000000000000000000000001010",
+        "https://bscscan.com/token/0xCC42724C6683B7E57334c4E856f4c9965ED682bD",
+        "https://moonriver.moonscan.io/token/0x682f81e57eaa716504090c3ecba8595fb54561d8",
+        "https://moonbeam.moonscan.io/token/0x3405A1bd46B85c5C029483FbECf2F3E611026e45",
+        "https://explorer.energi.network/token/0x98997e1651919faeacee7b96afbb3dfd96cb6036",
+        "https://www.oklink.com/polygon",
+        "https://3xpl.com/polygon",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "https://discord.com/invite/XvpHAxZ", "https://t.me/PolygonAnnouncements"],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "0xPolygon",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "polygonofficial",
+      "subreddit_url": "https://www.reddit.com/r/maticnetwork/",
+      "repos_url": {
+        "github": [
+          "https://github.com/maticnetwork/contracts",
+          "https://github.com/maticnetwork/heimdall",
+          "https://github.com/maticnetwork/matic.js",
+          "https://github.com/maticnetwork/eth-dagger.js",
+          "https://github.com/maticnetwork/sol-trace"
+        ],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+      "small": "https://assets.coingecko.com/coins/images/4713/small/matic-token-icon.png?1624446912",
+      "large": "https://assets.coingecko.com/coins/images/4713/large/matic-token-icon.png?1624446912"
+    },
+    "country_origin": "IN",
+    "genesis_date": null,
+    "contract_address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+    "sentiment_votes_up_percentage": 82.31,
+    "sentiment_votes_down_percentage": 17.69,
+    "ico_data": {
+      "ico_start_date": null,
+      "ico_end_date": null,
+      "short_desc": "Scalable and Instant Blockchain Transactions",
+      "description": null,
+      "links": {},
+      "softcap_currency": "",
+      "hardcap_currency": "",
+      "total_raised_currency": "",
+      "softcap_amount": null,
+      "hardcap_amount": null,
+      "total_raised": null,
+      "quote_pre_sale_currency": "USD",
+      "base_pre_sale_amount": "1.0",
+      "quote_pre_sale_amount": "0.0026",
+      "quote_public_sale_currency": "USD",
+      "base_public_sale_amount": 1,
+      "quote_public_sale_amount": 0.00263,
+      "accepting_currencies": "",
+      "country_origin": "IN",
+      "pre_sale_start_date": null,
+      "pre_sale_end_date": null,
+      "whitelist_url": "",
+      "whitelist_start_date": null,
+      "whitelist_end_date": null,
+      "bounty_detail_url": "",
+      "amount_for_sale": null,
+      "kyc_required": true,
+      "whitelist_available": false,
+      "pre_sale_available": null,
+      "pre_sale_ended": false
+    },
+    "watchlist_portfolio_users": 535830,
+    "market_cap_rank": 14,
+    "coingecko_rank": 66,
+    "coingecko_score": 48.86,
+    "developer_score": 62.496,
+    "community_score": 12.154,
+    "liquidity_score": 68.532,
+    "public_interest_score": 0.053,
+    "market_data": {
+      "current_price": {
+        "usd": 0.702522
+      },
+      "total_value_locked": {
+        "usd": 5815407811
+      },
+      "mcap_to_tvl_ratio": 1.13,
+      "fdv_to_tvl_ratio": 1.21,
+      "roi": {
+        "times": 266.1186842773179,
+        "currency": "usd",
+        "percentage": 26611.86842773179
+      },
+      "ath": {
+        "usd": 2.92
+      },
+      "ath_change_percentage": {
+        "usd": -75.9096
+      },
+      "ath_date": {
+        "usd": "2021-12-27T02:08:34.307Z"
+      },
+      "atl": {
+        "usd": 0.00314376
+      },
+      "atl_change_percentage": {
+        "usd": 22247.10627
+      },
+      "atl_date": {
+        "usd": "2019-05-10T00:00:00.000Z"
+      },
+      "market_cap": {
+        "usd": 6551866821
+      },
+      "market_cap_rank": 14,
+      "fully_diluted_valuation": {
+        "usd": 7030300517
+      },
+      "total_volume": {
+        "usd": 248901670
+      },
+      "high_24h": {
+        "usd": 0.703873
+      },
+      "low_24h": {
+        "usd": 0.667016
+      },
+      "price_change_24h": 0.03376024,
+      "price_change_percentage_24h": 5.04817,
+      "price_change_percentage_7d": 8.53485,
+      "price_change_percentage_14d": 17.0861,
+      "price_change_percentage_30d": -22.1878,
+      "price_change_percentage_60d": -28.85322,
+      "price_change_percentage_200d": -20.51694,
+      "price_change_percentage_1y": 53.08247,
+      "market_cap_change_24h": 307275504,
+      "market_cap_change_percentage_24h": 4.92067,
+      "price_change_24h_in_currency": {
+        "usd": 0.03376024
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.30904
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 5.04817
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 8.53485
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 17.0861
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -22.1878
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -28.85322
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -20.51694
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 53.08247
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 307275504
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.92067
+      },
+      "total_supply": 10000000000,
+      "max_supply": 10000000000,
+      "circulating_supply": 9319469069.28493,
+      "last_updated": "2023-07-03T17:58:45.964Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 55039,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:58:45.964Z"
+  },
+  {
+    "id": "metaverse-index",
+    "symbol": "mvi",
+    "name": "Metaverse Index",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+      "polygon-pos": "0xfe712251173a2cd5f5be2b46bb528328ea3565e1"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0xfe712251173a2cd5f5be2b46bb528328ea3565e1"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "TokenSets",
+      "DeFi Index",
+      "Decentralized Finance (DeFi)",
+      "Structured Products",
+      "Polygon Ecosystem",
+      "Metaverse",
+      "Ethereum Ecosystem",
+      "Index",
+      "NFT Index"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "The Metaverse Index is designed to capture the trend of entertainment, sports and business shifting to a virtual environment, with economic activity in this environment taking place on the Ethereum blockchain.\r\n"
+    },
+    "links": {
+      "homepage": ["https://indexcoop.com/products/metaverse-index", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+        "https://ethplorer.io/address/0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+        "https://polygonscan.com/token/0xfe712251173a2cd5f5be2b46bb528328ea3565e1",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": [
+        "https://discord.com/invite/indexcoop",
+        "https://www.youtube.com/channel/UCsNqHm_2LKh0E4A0vf25pIw",
+        ""
+      ],
+      "announcement_url": ["https://indexcoop.com/blog", ""],
+      "twitter_screen_name": "indexcoop",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14684/thumb/MVI_logo.png?1617776444",
+      "small": "https://assets.coingecko.com/coins/images/14684/small/MVI_logo.png?1617776444",
+      "large": "https://assets.coingecko.com/coins/images/14684/large/MVI_logo.png?1617776444"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 12107,
+    "market_cap_rank": 1502,
+    "coingecko_rank": 2137,
+    "coingecko_score": 14.308,
+    "developer_score": 0,
+    "community_score": 9.188,
+    "liquidity_score": 3.744,
+    "public_interest_score": 0.003,
+    "market_data": {
+      "current_price": {
+        "usd": 15.62
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 372.65
+      },
+      "ath_change_percentage": {
+        "usd": -95.80002
+      },
+      "ath_date": {
+        "usd": "2021-11-25T10:15:50.405Z"
+      },
+      "atl": {
+        "usd": 12.88
+      },
+      "atl_change_percentage": {
+        "usd": 21.47384
+      },
+      "atl_date": {
+        "usd": "2023-06-14T21:04:06.935Z"
+      },
+      "market_cap": {
+        "usd": 2589267
+      },
+      "market_cap_rank": 1502,
+      "fully_diluted_valuation": {
+        "usd": 2589267
+      },
+      "total_volume": {
+        "usd": 1174.3
+      },
+      "high_24h": {
+        "usd": 15.74
+      },
+      "low_24h": {
+        "usd": 14.95
+      },
+      "price_change_24h": 0.064745,
+      "price_change_percentage_24h": 0.4163,
+      "price_change_percentage_7d": 3.95561,
+      "price_change_percentage_14d": 13.13825,
+      "price_change_percentage_30d": -19.60678,
+      "price_change_percentage_60d": -24.87491,
+      "price_change_percentage_200d": -18.98472,
+      "price_change_percentage_1y": -56.05888,
+      "market_cap_change_24h": -1334.24889301,
+      "market_cap_change_percentage_24h": -0.0515,
+      "price_change_24h_in_currency": {
+        "usd": 0.064745
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.03492
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.4163
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 3.95561
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 13.13825
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -19.60678
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -24.87491
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -18.98472
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -56.05888
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": -1334.248893004842
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": -0.0515
+      },
+      "total_supply": 165854.848510058,
+      "max_supply": null,
+      "circulating_supply": 165854.848510058,
+      "last_updated": "2023-07-03T17:54:07.003Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:54:07.003Z"
+  },
+  {
+    "id": "monerium-eur-money",
+    "symbol": "eure",
+    "name": "Monerium EUR emoney",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x3231cb76718cdef2155fc47b5286d82e6eda273f",
+      "polygon-pos": "0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6",
+      "xdai": "0xcb444e90d8198415266c6a2724b7900fb12fc56e"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x3231cb76718cdef2155fc47b5286d82e6eda273f"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6"
+      },
+      "xdai": {
+        "decimal_place": 18,
+        "contract_address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Polygon Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "Stablecoins",
+      "EUR Stablecoin",
+      "Ethereum Ecosystem"
+    ],
+    "public_notice": null,
+    "additional_notices": [
+      "Kindly be aware of <a href='https://www.coingecko.com/en/glossary/rug-pulled' target='_blank'>liquidity-related risks</a>. This notice is not directed at any project in particular, and is more of a cautionary reminder."
+    ],
+    "description": {
+      "en": "Monerium is the first and, to date, only company authorized to issue money on blockchains under current European financial regulation and proposed Market in Crypto-Assets regulation. We have issued EUR, USD, GBP, and ISK as e-money tokens on Ethereum and EUR on Algorand. Monerium also operates a gateway for instant transfers of EUR between bank accounts and blockchain wallets / smart contracts. Founded by crypto OGs and repeat entrepreneurs, Monerium is backed by Taavet+Sten, Crowberry Capital, ConsenSys, Algorand, and several entrepreneurs and early crypto adopters. "
+    },
+    "links": {
+      "homepage": ["https://monerium.com/tokens/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x3231cb76718cdef2155fc47b5286d82e6eda273f",
+        "https://ethplorer.io/address/0x3231cb76718cdef2155fc47b5286d82e6eda273f",
+        "https://polygonscan.com/token/0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6",
+        "https://gnosisscan.io/token/0xcB444e90D8198415266c6a2724b7900fb12FC56E",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "", ""],
+      "announcement_url": ["https://medium.com/@monerium", ""],
+      "twitter_screen_name": "monerium",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/monerium/smart-contracts"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/23354/thumb/eur.png?1643926562",
+      "small": "https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562",
+      "large": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1643926562"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x3231cb76718cdef2155fc47b5286d82e6eda273f",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 95,
+    "market_cap_rank": null,
+    "coingecko_rank": 2413,
+    "coingecko_score": 13.153,
+    "developer_score": 46.147,
+    "community_score": 6.438,
+    "liquidity_score": 1,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 1.09
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1.17
+      },
+      "ath_change_percentage": {
+        "usd": -6.73347
+      },
+      "ath_date": {
+        "usd": "2023-05-14T07:15:58.558Z"
+      },
+      "atl": {
+        "usd": 0.951958
+      },
+      "atl_change_percentage": {
+        "usd": 14.4361
+      },
+      "atl_date": {
+        "usd": "2022-09-06T17:31:09.870Z"
+      },
+      "market_cap": {
+        "usd": 0
+      },
+      "market_cap_rank": null,
+      "fully_diluted_valuation": {
+        "usd": 1180961
+      },
+      "total_volume": {
+        "usd": 25508
+      },
+      "high_24h": {
+        "usd": 1.095
+      },
+      "low_24h": {
+        "usd": 1.083
+      },
+      "price_change_24h": 0.00049393,
+      "price_change_percentage_24h": 0.04535,
+      "price_change_percentage_7d": -0.58409,
+      "price_change_percentage_14d": 0.00707,
+      "price_change_percentage_30d": 1.99664,
+      "price_change_percentage_60d": -1.36496,
+      "price_change_percentage_200d": 3.60205,
+      "price_change_percentage_1y": 0.61775,
+      "market_cap_change_24h": 0,
+      "market_cap_change_percentage_24h": 0,
+      "price_change_24h_in_currency": {
+        "usd": 0.00049393
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.01568
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.04535
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": -0.58409
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 0.00707
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 1.99664
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -1.36496
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 3.60205
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 0.61775
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 0
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 0
+      },
+      "total_supply": 1083746,
+      "max_supply": 1083746,
+      "circulating_supply": 0,
+      "last_updated": "2023-07-03T17:58:53.718Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:58:53.718Z"
+  },
+  {
+    "id": "origin-ether",
+    "symbol": "oeth",
+    "name": "Origin Ether",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Origin Ether (OETH) is a liquid staking yield aggregator on Ethereum. When staking ETH, there are various liquid staking derivatives (LSDs) to choose from, the largest being Lido, Coinbase, Rocket Pool, and Frax. OETH is an LSD aggregator that combines the yield-generating functions of the largest LSDs into one single token. OETH is permissionless, fully collateralized, self-custodial, passive, and fully transparent. There are no lock-ups or conditions required to earn yield, yield is distributed daily and automatically directly into users' wallets. Built by the team at Origin Protocol."
+    },
+    "links": {
+      "homepage": ["https://oeth.com/", "https://originprotocol.com/", "https://ousd.com/"],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3",
+        "https://ethplorer.io/address/0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": [
+        "https://www.tiktok.com/@origin_protocol",
+        "https://instagram.com/originprotocol",
+        "https://www.linkedin.com/company/originprotocol/"
+      ],
+      "chat_url": [
+        "https://discord.com/invite/ogn",
+        "https://blog.originprotocol.com/",
+        "https://www.youtube.com/c/originprotocol"
+      ],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "OriginProtocol",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "originprotocol",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/29733/thumb/OETH.png?1681094770",
+      "small": "https://assets.coingecko.com/coins/images/29733/small/OETH.png?1681094770",
+      "large": "https://assets.coingecko.com/coins/images/29733/large/OETH.png?1681094770"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 73,
+    "market_cap_rank": 429,
+    "coingecko_rank": null,
+    "coingecko_score": 0,
+    "developer_score": 0,
+    "community_score": 0,
+    "liquidity_score": 0,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 1962.77
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1972.36
+      },
+      "ath_change_percentage": {
+        "usd": -0.45439
+      },
+      "ath_date": {
+        "usd": "2023-07-03T08:20:20.785Z"
+      },
+      "atl": {
+        "usd": 1625.4
+      },
+      "atl_change_percentage": {
+        "usd": 20.79438
+      },
+      "atl_date": {
+        "usd": "2023-06-15T09:33:43.370Z"
+      },
+      "market_cap": {
+        "usd": 45699757
+      },
+      "market_cap_rank": 429,
+      "fully_diluted_valuation": {
+        "usd": 45699757
+      },
+      "total_volume": {
+        "usd": 72609
+      },
+      "high_24h": {
+        "usd": 1972.36
+      },
+      "low_24h": {
+        "usd": 1907.77
+      },
+      "price_change_24h": 52.59,
+      "price_change_percentage_24h": 2.75292,
+      "price_change_percentage_7d": 5.37429,
+      "price_change_percentage_14d": 14.34958,
+      "price_change_percentage_30d": 3.9985,
+      "price_change_percentage_60d": 0,
+      "price_change_percentage_200d": 0,
+      "price_change_percentage_1y": 0,
+      "market_cap_change_24h": 1271644,
+      "market_cap_change_percentage_24h": 2.86225,
+      "price_change_24h_in_currency": {
+        "usd": 52.59
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.05821
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.75292
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 5.37429
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 14.34958
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 3.9985
+      },
+      "price_change_percentage_60d_in_currency": {},
+      "price_change_percentage_200d_in_currency": {},
+      "price_change_percentage_1y_in_currency": {},
+      "market_cap_change_24h_in_currency": {
+        "usd": 1271644
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.86225
+      },
+      "total_supply": 23278,
+      "max_supply": 23278,
+      "circulating_supply": 23278,
+      "last_updated": "2023-07-03T17:59:05.384Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:59:05.384Z"
+  },
+  {
+    "id": "reflexer-ungovernance-token",
+    "symbol": "flx",
+    "name": "Reflexer Ungovernance",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x6243d8cea23066d098a15582d81a598b4e8391f4"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x6243d8cea23066d098a15582d81a598b4e8391f4"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "Decentralized Finance (DeFi)"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "FLX will have two different core functions:\r\n\r\n- Lender of last resort: similar to other models such as the Maker protocol, the RAI system will have surplus and debt auctions. Debt auctions will autonomously mint and auction new FLX in case the system is underwater.\r\n\r\n- Ungoverning the RAI system: once the vast majority of governance capabilities are completely removed from the system, the community will be able to decide on how, when and if to securely governance minimize any remaining components. FLX will facilitate further ungovernance and allow the community to take decisions on how to remove themselves from discretion over the protocol."
+    },
+    "links": {
+      "homepage": ["https://reflexer.finance/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x6243d8cea23066d098a15582d81a598b4e8391f4",
+        "https://ethplorer.io/address/0x6243d8cea23066d098a15582d81a598b4e8391f4",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/83t3xKT", "", ""],
+      "announcement_url": ["", ""],
+      "twitter_screen_name": "reflexerfinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/reflexer-labs"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/14123/thumb/EAfYdwgd_400x400.jpg?1614564508",
+      "small": "https://assets.coingecko.com/coins/images/14123/small/EAfYdwgd_400x400.jpg?1614564508",
+      "large": "https://assets.coingecko.com/coins/images/14123/large/EAfYdwgd_400x400.jpg?1614564508"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x6243d8cea23066d098a15582d81a598b4e8391f4",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 3719,
+    "market_cap_rank": 856,
+    "coingecko_rank": 1864,
+    "coingecko_score": 15.583,
+    "developer_score": 0,
+    "community_score": 8.384,
+    "liquidity_score": 7.57,
+    "public_interest_score": 0.001,
+    "market_data": {
+      "current_price": {
+        "usd": 18.09
+      },
+      "total_value_locked": {
+        "usd": 31904304
+      },
+      "mcap_to_tvl_ratio": 0.41,
+      "fdv_to_tvl_ratio": 0.55,
+      "roi": null,
+      "ath": {
+        "usd": 1839.79
+      },
+      "ath_change_percentage": {
+        "usd": -99.01748
+      },
+      "ath_date": {
+        "usd": "2021-04-15T20:14:47.371Z"
+      },
+      "atl": {
+        "usd": 9.73
+      },
+      "atl_change_percentage": {
+        "usd": 85.77607
+      },
+      "atl_date": {
+        "usd": "2023-01-25T01:31:38.657Z"
+      },
+      "market_cap": {
+        "usd": 13235081
+      },
+      "market_cap_rank": 856,
+      "fully_diluted_valuation": {
+        "usd": 17583314
+      },
+      "total_volume": {
+        "usd": 41090
+      },
+      "high_24h": {
+        "usd": 18.11
+      },
+      "low_24h": {
+        "usd": 17.08
+      },
+      "price_change_24h": 0.806203,
+      "price_change_percentage_24h": 4.6632,
+      "price_change_percentage_7d": 18.09016,
+      "price_change_percentage_14d": 28.68592,
+      "price_change_percentage_30d": 22.15764,
+      "price_change_percentage_60d": -0.8564,
+      "price_change_percentage_200d": 33.78232,
+      "price_change_percentage_1y": -25.21308,
+      "market_cap_change_24h": 556119,
+      "market_cap_change_percentage_24h": 4.38615,
+      "price_change_24h_in_currency": {
+        "usd": 0.806203
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.38434
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 4.6632
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 18.09016
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 28.68592
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 22.15764
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -0.8564
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 33.78232
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -25.21308
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 556119
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.38615
+      },
+      "total_supply": 972622.296129312,
+      "max_supply": 972622.296129312,
+      "circulating_supply": 732099.458631534,
+      "last_updated": "2023-07-03T17:59:41.640Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T17:59:41.640Z"
+  },
+  {
+    "id": "ribbon-finance",
+    "symbol": "rbn",
+    "name": "Ribbon Finance",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x6123b0049f904d730db3c36a31167d9d4121fa6b"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Ethereum Ecosystem",
+      "Structured Products",
+      "Options",
+      "Decentralized Finance (DeFi)",
+      "Governance"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Ribbon Finance is a new protocol that helps users access crypto structured products for DeFi. It combines options, futures, and fixed income to improve a portfolio's risk-return profile."
+    },
+    "links": {
+      "homepage": ["https://www.ribbon.finance/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+        "https://ethplorer.io/address/0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+        "https://etherscan.io/token/0x6123b0049f904d730db3c36a31167d9d4121fa6b",
+        "https://ethplorer.io/address/0x6123b0049f904d730db3c36a31167d9d4121fa6b",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/85gcVafPyN", "", ""],
+      "announcement_url": ["https://ribbonfinance.medium.com/", ""],
+      "twitter_screen_name": "ribbonfinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/ribbon-finance"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723",
+      "small": "https://assets.coingecko.com/coins/images/15823/small/RBN_64x64.png?1633529723",
+      "large": "https://assets.coingecko.com/coins/images/15823/large/RBN_64x64.png?1633529723"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b",
+    "sentiment_votes_up_percentage": 100,
+    "sentiment_votes_down_percentage": 0,
+    "watchlist_portfolio_users": 10567,
+    "market_cap_rank": 211,
+    "coingecko_rank": 992,
+    "coingecko_score": 21.527,
+    "developer_score": 0,
+    "community_score": 8.934,
+    "liquidity_score": 27.696,
+    "public_interest_score": 0.006,
+    "market_data": {
+      "current_price": {
+        "usd": 0.185966
+      },
+      "total_value_locked": {
+        "usd": 28225806
+      },
+      "mcap_to_tvl_ratio": 4.84,
+      "fdv_to_tvl_ratio": 6.6,
+      "roi": null,
+      "ath": {
+        "usd": 5.54
+      },
+      "ath_change_percentage": {
+        "usd": -96.63704
+      },
+      "ath_date": {
+        "usd": "2021-10-07T22:30:49.258Z"
+      },
+      "atl": {
+        "usd": 0.12452
+      },
+      "atl_change_percentage": {
+        "usd": 49.6694
+      },
+      "atl_date": {
+        "usd": "2023-05-18T09:35:07.716Z"
+      },
+      "market_cap": {
+        "usd": 136715561
+      },
+      "market_cap_rank": 211,
+      "fully_diluted_valuation": {
+        "usd": 186205008
+      },
+      "total_volume": {
+        "usd": 268865
+      },
+      "high_24h": {
+        "usd": 0.187144
+      },
+      "low_24h": {
+        "usd": 0.184752
+      },
+      "price_change_24h": 0.00040346,
+      "price_change_percentage_24h": 0.21742,
+      "price_change_percentage_7d": 2.45682,
+      "price_change_percentage_14d": 8.155,
+      "price_change_percentage_30d": 14.06026,
+      "price_change_percentage_60d": 7.69189,
+      "price_change_percentage_200d": -26.58159,
+      "price_change_percentage_1y": -19.57204,
+      "market_cap_change_24h": 839591,
+      "market_cap_change_percentage_24h": 0.61791,
+      "price_change_24h_in_currency": {
+        "usd": 0.00040346
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -0.0888
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 0.21742
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 2.45682
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 8.155
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 14.06026
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 7.69189
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -26.58159
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -19.57204
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 839591
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 0.61791
+      },
+      "total_supply": 1000000000,
+      "max_supply": 1000000000,
+      "circulating_supply": 734220644.272479,
+      "last_updated": "2023-07-03T18:00:42.219Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T18:00:42.219Z"
+  },
+  {
+    "id": "rocket-pool",
+    "symbol": "rpl",
+    "name": "Rocket Pool",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      "arbitrum-one": "0xb766039cc6db368759c1e56b79affe831d0cc507",
+      "polygon-pos": "0x7205705771547cf79201111b4bd8aaf29467b9ec"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xb766039cc6db368759c1e56b79affe831d0cc507"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x7205705771547cf79201111b4bd8aaf29467b9ec"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Polygon Ecosystem",
+      "Arbitrum Ecosystem",
+      "Liquid Staking Governance Tokens",
+      "Ethereum Ecosystem",
+      "Decentralized Finance (DeFi)",
+      "Business Services",
+      "Infrastructure"
+    ],
+    "public_notice": "Rocket Pool has migrated to a new contract address (0xd33526068d116ce69f19a9ee46f0bd304f21a51f). For more information, please read: https://medium.com/rocket-pool/rocket-pool-rpl-token-upgrade-new-addresses-e96c12c55adf",
+    "additional_notices": [],
+    "description": {
+      "en": "Rocket Pool is Ethereum’s most decentralised liquid staking protocol.\r\nLiquid stakers can participate by depositing as little as 0.01 ETH to receive the rETH liquid staking token.\r\nRocket Pool is a fully non-custodial solution, and its node operators are economically-aligned to perform well for stakers. Joining as a node operator is fully permissionless and requires just 16 ETH (instead of the usual 32). A boosted ROI is provided from both operator commission plus RPL rewards. The Rocket Pool team have been in the staking space since its inception in 2016, which gives them a pedigree and track record without peer."
+    },
+    "links": {
+      "homepage": ["https://www.rocketpool.net", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "https://ethplorer.io/address/0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "https://arbiscan.io/token/0xB766039cc6DB368759C1E56B79AFfE831d0Cc507",
+        "https://polygonscan.com/token/0x7205705771547cf79201111b4bd8aaf29467b9ec",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discordapp.com/invite/tCRG54c", "", ""],
+      "announcement_url": ["https://medium.com/rocket-pool", ""],
+      "twitter_screen_name": "Rocket_Pool",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": "https://www.reddit.com/r/rocketpool",
+      "repos_url": {
+        "github": ["https://github.com/rocket-pool/rocketpool", "https://github.com/rocket-pool/smartnode"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/2090/thumb/rocket_pool_%28RPL%29.png?1637662441",
+      "small": "https://assets.coingecko.com/coins/images/2090/small/rocket_pool_%28RPL%29.png?1637662441",
+      "large": "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1637662441"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+    "sentiment_votes_up_percentage": 85.71,
+    "sentiment_votes_down_percentage": 14.29,
+    "ico_data": {
+      "ico_start_date": "2017-11-25T00:00:00.000Z",
+      "ico_end_date": "2018-01-07T00:00:00.000Z",
+      "short_desc": "A decentralised Ethereum Proof of Stake Pool designed to be compatible with Casper.",
+      "description": "Rocket Pool is a next generation pool designed to work with Casper, the new consensus protocol that Ethereum will transition to in 2018. It was the first working implementation of a Proof of Stake pool and features several first to market features; such as load balancing across multiple cloud hosting providers using smart contracts, minipools, widow addresses and deposit tokens. Rocket Pool isn’t just a whitepaper, it’s actual code.",
+      "links": {
+        "web": "https://www.rocketpool.net",
+        "slack": "http://slack.rocketpool.net",
+        "github": "https://github.com/darcius/rocketpool",
+        "medium": "https://medium.com/rocket-pool",
+        "twitter": "https://twitter.com/Rocket_Pool",
+        "linkedin": "https://www.linkedin.com/in/david-rugendyke-260a2a60/",
+        "whitepaper": "https://www.rocketpool.net/files/RocketPoolWhitePaper.pdf"
+      },
+      "softcap_currency": "",
+      "hardcap_currency": "",
+      "total_raised_currency": "",
+      "softcap_amount": null,
+      "hardcap_amount": null,
+      "total_raised": null,
+      "quote_pre_sale_currency": "",
+      "base_pre_sale_amount": null,
+      "quote_pre_sale_amount": null,
+      "quote_public_sale_currency": "",
+      "base_public_sale_amount": 0,
+      "quote_public_sale_amount": 0,
+      "accepting_currencies": "",
+      "country_origin": "",
+      "pre_sale_start_date": null,
+      "pre_sale_end_date": null,
+      "whitelist_url": "",
+      "whitelist_start_date": null,
+      "whitelist_end_date": null,
+      "bounty_detail_url": "",
+      "amount_for_sale": null,
+      "kyc_required": true,
+      "whitelist_available": null,
+      "pre_sale_available": null,
+      "pre_sale_ended": false
+    },
+    "watchlist_portfolio_users": 21340,
+    "market_cap_rank": 63,
+    "coingecko_rank": 92,
+    "coingecko_score": 46.108,
+    "developer_score": 64.98,
+    "community_score": 35.995,
+    "liquidity_score": 34.907,
+    "public_interest_score": 0.005,
+    "market_data": {
+      "current_price": {
+        "usd": 39.17
+      },
+      "total_value_locked": {
+        "usd": 1934216825
+      },
+      "mcap_to_tvl_ratio": 0.39,
+      "fdv_to_tvl_ratio": 0.39,
+      "roi": null,
+      "ath": {
+        "usd": 61.9
+      },
+      "ath_change_percentage": {
+        "usd": -36.71756
+      },
+      "ath_date": {
+        "usd": "2023-04-16T19:20:19.534Z"
+      },
+      "atl": {
+        "usd": 0.00884718
+      },
+      "atl_change_percentage": {
+        "usd": 442645.87942
+      },
+      "atl_date": {
+        "usd": "2018-08-28T00:00:00.000Z"
+      },
+      "market_cap": {
+        "usd": 762938416
+      },
+      "market_cap_rank": 63,
+      "fully_diluted_valuation": {
+        "usd": 762938416
+      },
+      "total_volume": {
+        "usd": 7598928
+      },
+      "high_24h": {
+        "usd": 39.6
+      },
+      "low_24h": {
+        "usd": 36.24
+      },
+      "price_change_24h": 2.9,
+      "price_change_percentage_24h": 7.99955,
+      "price_change_percentage_7d": 3.01137,
+      "price_change_percentage_14d": -2.81049,
+      "price_change_percentage_30d": -20.44853,
+      "price_change_percentage_60d": -22.94912,
+      "price_change_percentage_200d": 89.94042,
+      "price_change_percentage_1y": 260.26534,
+      "market_cap_change_24h": 53622036,
+      "market_cap_change_percentage_24h": 7.55968,
+      "price_change_24h_in_currency": {
+        "usd": 2.9
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.11527
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 7.99955
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 3.01137
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": -2.81049
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -20.44853
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -22.94912
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 89.94042
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 260.26534
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 53622036
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 7.55968
+      },
+      "total_supply": 19474470.0383936,
+      "max_supply": null,
+      "circulating_supply": 19474470.0383936,
+      "last_updated": "2023-07-03T18:01:50.646Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 345936,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T18:01:50.646Z"
+  },
+  {
+    "id": "shiba-inu",
+    "symbol": "shib",
+    "name": "Shiba Inu",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "BNB Chain Ecosystem", "Meme"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Shiba Inu (SHIB) is a meme token which began as a fun currency and has now transformed into a decentralized ecosystem. During the initial launch, 50% of the supply was allocated into Vitalik Buterin's ethereum wallet. \r\n\r\nAs a result of that, Vitalik proceeded to donate 10% of his SHIB holdings to a COVID-19 relief effort in India and the remaining 40% is burnt forever. That donation was worth about $1 billion at that time, which makes it one of the largest donation ever in the world.\r\n\r\nWhat is the Shiba Inu community working on right now? The Shiba Inu team launched a decentralized exchange called Shibaswap with 2 new tokens, LEASH and BONE. LEASH is a scarce supply token that is used to offer incentives on Shibaswap. BONE is the governance token for holders to vote on proposals on Doggy DAO."
+    },
+    "links": {
+      "homepage": ["https://shibatoken.com/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+        "https://ethplorer.io/address/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+        "https://bscscan.com/token/0x2859e4544c4bb03966803b044a93563bd2d0dd4d",
+        "https://explorer.energi.network/token/0x7fDb933327aa6989ae706001c2EA54BA5E046e79",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/shibatoken", "", ""],
+      "announcement_url": ["https://blog.shibaswap.com/", ""],
+      "twitter_screen_name": "Shibtoken",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "ShibaInu_Dogecoinkiller",
+      "subreddit_url": "https://www.reddit.com/r/SHIBArmy/",
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446",
+      "small": "https://assets.coingecko.com/coins/images/11939/small/shiba.png?1622619446",
+      "large": "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1622619446"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+    "sentiment_votes_up_percentage": 75.53,
+    "sentiment_votes_down_percentage": 24.47,
+    "watchlist_portfolio_users": 595452,
+    "market_cap_rank": 18,
+    "coingecko_rank": 132,
+    "coingecko_score": 42.68,
+    "developer_score": 0,
+    "community_score": 56.215,
+    "liquidity_score": 66.79,
+    "public_interest_score": 0.01,
+    "market_data": {
+      "current_price": {
+        "usd": 0.00000774
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 0.00008616
+      },
+      "ath_change_percentage": {
+        "usd": -91.02057
+      },
+      "ath_date": {
+        "usd": "2021-10-28T03:54:55.568Z"
+      },
+      "atl": {
+        "usd": 5.6366e-11
+      },
+      "atl_change_percentage": {
+        "usd": 13725401.29466
+      },
+      "atl_date": {
+        "usd": "2020-11-28T11:26:25.838Z"
+      },
+      "market_cap": {
+        "usd": 4555192759
+      },
+      "market_cap_rank": 18,
+      "fully_diluted_valuation": {
+        "usd": 7729237878
+      },
+      "total_volume": {
+        "usd": 102770543
+      },
+      "high_24h": {
+        "usd": 0.00000775
+      },
+      "low_24h": {
+        "usd": 0.00000754
+      },
+      "price_change_24h": 1.69261e-7,
+      "price_change_percentage_24h": 2.2368,
+      "price_change_percentage_7d": 1.78998,
+      "price_change_percentage_14d": 8.05063,
+      "price_change_percentage_30d": -9.96591,
+      "price_change_percentage_60d": -22.24748,
+      "price_change_percentage_200d": -12.55483,
+      "price_change_percentage_1y": -22.05648,
+      "market_cap_change_24h": 92709463,
+      "market_cap_change_percentage_24h": 2.07753,
+      "price_change_24h_in_currency": {
+        "usd": 1.69261e-7
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.40265
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.2368
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 1.78998
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 8.05063
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -9.96591
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -22.24748
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -12.55483
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -22.05648
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 92709463
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.07753
+      },
+      "total_supply": 999988864114449,
+      "max_supply": null,
+      "circulating_supply": 589339092058245.9,
+      "last_updated": "2023-07-03T18:01:31.410Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 4476531,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T18:01:31.410Z"
+  },
+  {
+    "id": "staked-ether",
+    "symbol": "steth",
+    "name": "Lido Staked Ether",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "Liquid Staking Tokens", "Decentralized Finance (DeFi)", "Eth 2.0 Staking"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Lido Staked Ether (stETH) is a token that represents your staked ether in Lido, combining the value of initial deposit and staking rewards. stETH tokens are minted upon deposit and burned when redeemed. stETH token balances are pegged 1:1 to the ethers that are staked by Lido and the token’s balances are updated daily to reflect earnings and rewards. stETH tokens can be used as one would use ether, allowing you to earn ETH 2.0 staking rewards whilst benefiting from e.g. yields across decentralised finance products."
+    },
+    "links": {
+      "homepage": ["https://www.lido.fi", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+        "https://ethplorer.io/address/0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.com/invite/vgdPfhZ", "", ""],
+      "announcement_url": ["https://blog.lido.fi", ""],
+      "twitter_screen_name": "lidofinance",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "lidofinance",
+      "subreddit_url": "https://www.reddit.com/r/lidofinance/",
+      "repos_url": {
+        "github": ["https://github.com/lidofinance"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/13442/thumb/steth_logo.png?1608607546",
+      "small": "https://assets.coingecko.com/coins/images/13442/small/steth_logo.png?1608607546",
+      "large": "https://assets.coingecko.com/coins/images/13442/large/steth_logo.png?1608607546"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+    "sentiment_votes_up_percentage": 82.35,
+    "sentiment_votes_down_percentage": 17.65,
+    "watchlist_portfolio_users": 12546,
+    "market_cap_rank": 7,
+    "coingecko_rank": 253,
+    "coingecko_score": 34.763,
+    "developer_score": 0,
+    "community_score": 33.667,
+    "liquidity_score": 52.515,
+    "public_interest_score": 0.023,
+    "market_data": {
+      "current_price": {
+        "usd": 1963.97
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 4829.57
+      },
+      "ath_change_percentage": {
+        "usd": -59.31733
+      },
+      "ath_date": {
+        "usd": "2021-11-10T14:40:47.256Z"
+      },
+      "atl": {
+        "usd": 482.9
+      },
+      "atl_change_percentage": {
+        "usd": 306.87796
+      },
+      "atl_date": {
+        "usd": "2020-12-22T04:08:21.854Z"
+      },
+      "market_cap": {
+        "usd": 14801302349
+      },
+      "market_cap_rank": 7,
+      "fully_diluted_valuation": {
+        "usd": 14801368635
+      },
+      "total_volume": {
+        "usd": 28784898
+      },
+      "high_24h": {
+        "usd": 1972.05
+      },
+      "low_24h": {
+        "usd": 1905.72
+      },
+      "price_change_24h": 55.76,
+      "price_change_percentage_24h": 2.9219,
+      "price_change_percentage_7d": 6.3277,
+      "price_change_percentage_14d": 13.6889,
+      "price_change_percentage_30d": 4.09859,
+      "price_change_percentage_60d": 4.3887,
+      "price_change_percentage_200d": 56.33643,
+      "price_change_percentage_1y": 92.37555,
+      "market_cap_change_24h": 395310955,
+      "market_cap_change_percentage_24h": 2.74407,
+      "price_change_24h_in_currency": {
+        "usd": 55.76
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.11818
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 2.9219
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 6.3277
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 13.6889
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": 4.09859
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": 4.3887
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": 56.33643
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": 92.37555
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 395310955
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.74407
+      },
+      "total_supply": 7538552.46954925,
+      "max_supply": 7538552.46954925,
+      "circulating_supply": 7538518.70916658,
+      "last_updated": "2023-07-03T18:02:19.512Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": null,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T18:02:19.512Z"
+  },
+  {
+    "id": "strong",
+    "symbol": "strong",
+    "name": "Strong",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x990f341946a3fdb507ae7e52d17851b87168017c"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x990f341946a3fdb507ae7e52d17851b87168017c"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": ["Ethereum Ecosystem", "Infrastructure"],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Governance Token for StrongBlock DeFi platform."
+    },
+    "links": {
+      "homepage": ["https://strongblock.io/", "", ""],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x990f341946a3fdb507ae7e52d17851b87168017c",
+        "https://ethplorer.io/address/0x990f341946a3fdb507ae7e52d17851b87168017c",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["", "", ""],
+      "announcement_url": ["https://medium.com/@strongblockio", ""],
+      "twitter_screen_name": "Strongblock_io",
+      "facebook_username": "StrongBlock.io",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "strongblock_io",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": ["https://github.com/strongblock"],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/12092/thumb/STRONG-Token-256x256.png?1597823573",
+      "small": "https://assets.coingecko.com/coins/images/12092/small/STRONG-Token-256x256.png?1597823573",
+      "large": "https://assets.coingecko.com/coins/images/12092/large/STRONG-Token-256x256.png?1597823573"
+    },
+    "country_origin": "KY",
+    "genesis_date": null,
+    "contract_address": "0x990f341946a3fdb507ae7e52d17851b87168017c",
+    "sentiment_votes_up_percentage": null,
+    "sentiment_votes_down_percentage": null,
+    "watchlist_portfolio_users": 23692,
+    "market_cap_rank": 1519,
+    "coingecko_rank": 1902,
+    "coingecko_score": 15.427,
+    "developer_score": 0,
+    "community_score": 9.401,
+    "liquidity_score": 11.525,
+    "public_interest_score": 0,
+    "market_data": {
+      "current_price": {
+        "usd": 6.15
+      },
+      "total_value_locked": null,
+      "mcap_to_tvl_ratio": null,
+      "fdv_to_tvl_ratio": null,
+      "roi": null,
+      "ath": {
+        "usd": 1217.44
+      },
+      "ath_change_percentage": {
+        "usd": -99.47734
+      },
+      "ath_date": {
+        "usd": "2021-10-29T04:00:15.992Z"
+      },
+      "atl": {
+        "usd": 3.84
+      },
+      "atl_change_percentage": {
+        "usd": 65.58894
+      },
+      "atl_date": {
+        "usd": "2022-11-22T04:31:53.373Z"
+      },
+      "market_cap": {
+        "usd": 2539299
+      },
+      "market_cap_rank": 1519,
+      "fully_diluted_valuation": {
+        "usd": 3359025
+      },
+      "total_volume": {
+        "usd": 359967
+      },
+      "high_24h": {
+        "usd": 6.45
+      },
+      "low_24h": {
+        "usd": 6.15
+      },
+      "price_change_24h": -0.06679187716176,
+      "price_change_percentage_24h": -1.07473,
+      "price_change_percentage_7d": 4.89964,
+      "price_change_percentage_14d": 19.14315,
+      "price_change_percentage_30d": -2.62949,
+      "price_change_percentage_60d": -25.72997,
+      "price_change_percentage_200d": -38.64926,
+      "price_change_percentage_1y": -2.75886,
+      "market_cap_change_24h": 64258,
+      "market_cap_change_percentage_24h": 2.59625,
+      "price_change_24h_in_currency": {
+        "usd": -0.0667918771617515
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": -3.48505
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": -1.07473
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 4.89964
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 19.14315
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -2.62949
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -25.72997
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -38.64926
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -2.75886
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 64258
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 2.59625
+      },
+      "total_supply": 528886.0991521602,
+      "max_supply": 528886.0991521602,
+      "circulating_supply": 399818.3293437359,
+      "last_updated": "2023-07-03T18:02:00.057Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 1457952,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T18:02:00.057Z"
+  },
+  {
+    "id": "sushi",
+    "symbol": "sushi",
+    "name": "Sushi",
+    "asset_platform_id": "ethereum",
+    "platforms": {
+      "ethereum": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+      "near-protocol": "6b3595068778dd592e39a122f4f5a5cf09c90fe2.factory.bridge.near",
+      "solana": "ChVzxWRmrTeSgwd3Ui3UumcN8KX7VK3WaD4KGeSKpypj",
+      "binance-smart-chain": "0x947950bcc74888a40ffa2593c5798f11fc9124c4",
+      "polygon-pos": "0x0b3f868e0be5597d5db7feb59e1cadbb0fdda50a",
+      "fantom": "0xae75a438b2e0cb8bb01ec1e1e376de11d44477cc",
+      "harmony-shard-0": "0xbec775cb42abfa4288de81f387a9b1a3c4bc552a",
+      "avalanche": "0x37b608519f91f70f2eeb0e5ed9af4061722e4f76",
+      "arbitrum-one": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+      "sora": "0x0078f4e6c5113b3d8c954dff62ece8fc36a8411f86f1cbb48a52527e22e73be2",
+      "celo": "0xd15ec721c2a896512ad29c671997dd68f9593226",
+      "energi": "0x32aff6adc46331dac93e608a9cd4b0332d93a23a"
+    },
+    "detail_platforms": {
+      "ethereum": {
+        "decimal_place": 18,
+        "contract_address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2"
+      },
+      "near-protocol": {
+        "decimal_place": 18,
+        "contract_address": "6b3595068778dd592e39a122f4f5a5cf09c90fe2.factory.bridge.near"
+      },
+      "solana": {
+        "decimal_place": 8,
+        "contract_address": "ChVzxWRmrTeSgwd3Ui3UumcN8KX7VK3WaD4KGeSKpypj"
+      },
+      "binance-smart-chain": {
+        "decimal_place": 18,
+        "contract_address": "0x947950bcc74888a40ffa2593c5798f11fc9124c4"
+      },
+      "polygon-pos": {
+        "decimal_place": 18,
+        "contract_address": "0x0b3f868e0be5597d5db7feb59e1cadbb0fdda50a"
+      },
+      "fantom": {
+        "decimal_place": 18,
+        "contract_address": "0xae75a438b2e0cb8bb01ec1e1e376de11d44477cc"
+      },
+      "harmony-shard-0": {
+        "decimal_place": 18,
+        "contract_address": "0xbec775cb42abfa4288de81f387a9b1a3c4bc552a"
+      },
+      "avalanche": {
+        "decimal_place": 18,
+        "contract_address": "0x37b608519f91f70f2eeb0e5ed9af4061722e4f76"
+      },
+      "arbitrum-one": {
+        "decimal_place": 18,
+        "contract_address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a"
+      },
+      "sora": {
+        "decimal_place": 18,
+        "contract_address": "0x0078f4e6c5113b3d8c954dff62ece8fc36a8411f86f1cbb48a52527e22e73be2"
+      },
+      "celo": {
+        "decimal_place": 18,
+        "contract_address": "0xd15ec721c2a896512ad29c671997dd68f9593226"
+      },
+      "energi": {
+        "decimal_place": 18,
+        "contract_address": "0x32aff6adc46331dac93e608a9cd4b0332d93a23a"
+      }
+    },
+    "block_time_in_minutes": 0,
+    "hashing_algorithm": null,
+    "categories": [
+      "Harmony Ecosystem",
+      "Fantom Ecosystem",
+      "Ethereum Ecosystem",
+      "Arbitrum Ecosystem",
+      "OEC Ecosystem",
+      "Solana Ecosystem",
+      "Avalanche Ecosystem",
+      "BNB Chain Ecosystem",
+      "Gnosis Chain Ecosystem",
+      "Polygon Ecosystem",
+      "Yearn Ecosystem",
+      "Automated Market Maker (AMM)",
+      "Governance",
+      "Exchange-based Tokens",
+      "Decentralized Exchange (DEX)",
+      "Decentralized Finance (DeFi)",
+      "Yield Farming"
+    ],
+    "public_notice": null,
+    "additional_notices": [],
+    "description": {
+      "en": "Sushi is a DeFi protocol that is completely community-driven, serving up delicious interest for your held crypto assets.\r\n\r\nOn Sushi, you can take advantage of passive-income providing DeFi tools such as liquidity providing, yield farming and staking. Furthermore, due to the decentralized nature of being an AMM (Automated Market Maker), Sushi has fewer hurdles to execute your cryptocurrency trades and all fees are paid to the users who provided liquidity, just as it should be!"
+    },
+    "links": {
+      "homepage": ["https://sushi.com/", "", "https://forum.sushi.com/"],
+      "blockchain_site": [
+        "https://etherscan.io/token/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+        "https://ethplorer.io/address/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+        "https://bscscan.com/token/0x947950bcc74888a40ffa2593c5798f11fc9124c4",
+        "https://polygonscan.com/token/0x0b3f868e0be5597d5db7feb59e1cadbb0fdda50a",
+        "https://snowtrace.io/token/0x37b608519f91f70f2eeb0e5ed9af4061722e4f76",
+        "https://solscan.io/token/ChVzxWRmrTeSgwd3Ui3UumcN8KX7VK3WaD4KGeSKpypj",
+        "https://arbiscan.io/token/0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+        "https://ftmscan.com/token/0xae75a438b2e0cb8bb01ec1e1e376de11d44477cc",
+        "https://scan.meter.io/address/0xae75a438b2e0cb8bb01ec1e1e376de11d44477cc",
+        "https://nearblocks.io/token/6b3595068778dd592e39a122f4f5a5cf09c90fe2.factory.bridge.near"
+      ],
+      "official_forum_url": ["", "", ""],
+      "chat_url": ["https://discord.gg/MsVBwEc", "https://www.youtube.com/channel/UC7Mm_8m8C2sxbgxbQIDJJdQ", ""],
+      "announcement_url": ["https://medium.com/sushiswap-org", ""],
+      "twitter_screen_name": "sushiswap",
+      "facebook_username": "",
+      "bitcointalk_thread_identifier": null,
+      "telegram_channel_identifier": "",
+      "subreddit_url": null,
+      "repos_url": {
+        "github": [],
+        "bitbucket": []
+      }
+    },
+    "image": {
+      "thumb": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688",
+      "small": "https://assets.coingecko.com/coins/images/12271/small/512x512_Logo_no_chop.png?1606986688",
+      "large": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1606986688"
+    },
+    "country_origin": "",
+    "genesis_date": null,
+    "contract_address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+    "sentiment_votes_up_percentage": 77.78,
+    "sentiment_votes_down_percentage": 22.22,
+    "watchlist_portfolio_users": 110058,
+    "market_cap_rank": 214,
+    "coingecko_rank": 522,
+    "coingecko_score": 27.245,
+    "developer_score": 0,
+    "community_score": 10.469,
+    "liquidity_score": 52.772,
+    "public_interest_score": 0.056,
+    "market_data": {
+      "current_price": {
+        "usd": 0.707018
+      },
+      "total_value_locked": {
+        "usd": 369048656
+      },
+      "mcap_to_tvl_ratio": 0.37,
+      "fdv_to_tvl_ratio": 0.48,
+      "roi": null,
+      "ath": {
+        "usd": 23.38
+      },
+      "ath_change_percentage": {
+        "usd": -96.9738
+      },
+      "ath_date": {
+        "usd": "2021-03-13T23:44:36.774Z"
+      },
+      "atl": {
+        "usd": 0.475381
+      },
+      "atl_change_percentage": {
+        "usd": 48.81055
+      },
+      "atl_date": {
+        "usd": "2020-11-04T14:53:53.560Z"
+      },
+      "market_cap": {
+        "usd": 136487482
+      },
+      "market_cap_rank": 214,
+      "fully_diluted_valuation": {
+        "usd": 176990520
+      },
+      "total_volume": {
+        "usd": 22055545
+      },
+      "high_24h": {
+        "usd": 0.711991
+      },
+      "low_24h": {
+        "usd": 0.67404
+      },
+      "price_change_24h": 0.03282855,
+      "price_change_percentage_24h": 4.86933,
+      "price_change_percentage_7d": 5.36904,
+      "price_change_percentage_14d": 18.45812,
+      "price_change_percentage_30d": -16.79392,
+      "price_change_percentage_60d": -31.5316,
+      "price_change_percentage_200d": -36.56722,
+      "price_change_percentage_1y": -27.85528,
+      "market_cap_change_24h": 5843637,
+      "market_cap_change_percentage_24h": 4.47295,
+      "price_change_24h_in_currency": {
+        "usd": 0.03282855
+      },
+      "price_change_percentage_1h_in_currency": {
+        "usd": 0.23746
+      },
+      "price_change_percentage_24h_in_currency": {
+        "usd": 4.86933
+      },
+      "price_change_percentage_7d_in_currency": {
+        "usd": 5.36904
+      },
+      "price_change_percentage_14d_in_currency": {
+        "usd": 18.45812
+      },
+      "price_change_percentage_30d_in_currency": {
+        "usd": -16.79392
+      },
+      "price_change_percentage_60d_in_currency": {
+        "usd": -31.5316
+      },
+      "price_change_percentage_200d_in_currency": {
+        "usd": -36.56722
+      },
+      "price_change_percentage_1y_in_currency": {
+        "usd": -27.85528
+      },
+      "market_cap_change_24h_in_currency": {
+        "usd": 5843637
+      },
+      "market_cap_change_percentage_24h_in_currency": {
+        "usd": 4.47295
+      },
+      "total_supply": 249247264.219788,
+      "max_supply": 250000000,
+      "circulating_supply": 192789255.8554817,
+      "last_updated": "2023-07-03T18:02:29.046Z"
+    },
+    "public_interest_stats": {
+      "alexa_rank": 58279,
+      "bing_matches": null
+    },
+    "status_updates": [],
+    "last_updated": "2023-07-03T18:02:29.046Z"
+  }
 ]

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,29 +1,30 @@
 import fs from 'fs'
 import path from 'path'
 import { PlatformData, Platforms, TokenDetails, TokenInfo } from 'types'
+import { backOff } from 'exponential-backoff'
 
 const NETWORKS = ['ethereum', 'xdai']
 const COW_TOKEN_ID = 'cow-protocol'
 
-const TOKENS_PATH = path.join(process.cwd(), 'data', 'tokens.json')
+// const TOKENS_PATH = path.join(process.cwd(), 'data', 'tokens.json')
 const DESCRIPTIONS_DIR_PATH = path.join(process.cwd(), 'data', 'descriptions')
-
-const ALL_TOKENS = _getAllTokensData()
 
 /**
  *
  * @returns All token ids
  */
-export function getTokensIds(): string[] {
-  return ALL_TOKENS.map(({ id }) => id)
+export async function getTokensIds(): Promise<string[]> {
+  const tokensRaw = await _getAllTokensData()
+  return tokensRaw.map(({ id }) => id)
 }
 
 /**
  *
  * @returns All token info sorted by market cap, with COW at the top
  */
-export function getTokensInfo(): TokenInfo[] {
-  const tokens = ALL_TOKENS.map(_toTokenInfo)
+export async function getTokensInfo(): Promise<TokenInfo[]> {
+  const tokensRaw = await _getAllTokensData()
+  const tokens = tokensRaw.map(_toTokenInfo)
 
   let sortedTokens = tokens.sort(_sortTokensInfoByMarketCap)
 
@@ -46,22 +47,48 @@ export function getTokensInfo(): TokenInfo[] {
  */
 export async function getTokenDetails(coingeckoId: string): Promise<TokenDetails> {
   const id = coingeckoId.toLowerCase()
-  return ALL_TOKENS.find(({ id: _id }) => _id === id)
+  const tokensRaw = await _getAllTokensData()
+  return tokensRaw.find(({ id: _id }) => _id === id)
 }
 
 function _getDescriptionFilePaths(): string[] {
   return fs.readdirSync(DESCRIPTIONS_DIR_PATH, 'utf-8')
 }
 
-function _getTokensRawInfo(): any[] {
-  const tokenJson = fs.readFileSync(TOKENS_PATH, 'utf-8')
-  const tokenData = JSON.parse(tokenJson)
+async function fetchWithBackoff(url) {
+  return backOff(
+    () => {
+      console.log(`Fetching ${url}`)
+      return fetch(url).then((res) => {
+        if (!res.ok) {
+          throw new Error(`Error fetching list ${url}: Error ${res.status}, ${res.statusText}`)
+        }
 
-  return tokenData
+        return res.json()
+      })
+    },
+    {
+      numOfAttempts: 50,
+      maxDelay: 36000000, // 10min
+      startingDelay: 5000, // 5s
+      retry: (e, attemptNum) => {
+        console.log(`Error fetching ${url}, attempt ${attemptNum}. Retrying soon...`)
+        return true
+      },
+    }
+  )
 }
 
-function _getAllTokensData(): TokenDetails[] {
-  const tokenRawData = _getTokensRawInfo()
+function _getTokensRawInfo(): Promise<any[]> {
+  // const tokenJson = fs.readFileSync(TOKENS_PATH, 'utf-8')
+  // const tokenData = JSON.parse(tokenJson)
+
+  // return tokenData
+  return fetchWithBackoff('https://raw.githubusercontent.com/cowprotocol/cow-fi/develop/data/tokens.json')
+}
+
+async function _getAllTokensData(): Promise<TokenDetails[]> {
+  const tokenRawData = await _getTokensRawInfo()
 
   // Get manual descriptions
   const descriptionFilePaths = _getDescriptionFilePaths()

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -68,11 +68,8 @@ async function fetchWithBackoff(url) {
       })
     },
     {
-      numOfAttempts: 50,
-      maxDelay: 36000000, // 10min
-      startingDelay: 5000, // 5s
       retry: (e, attemptNum) => {
-        console.log(`Error fetching ${url}, attempt ${attemptNum}. Retrying soon...`)
+        console.log(`Error fetching ${url}, attempt ${attemptNum}. Retrying soon...`, e)
         return true
       },
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "classnames": "^2.3.1",
     "d3": "^7.8.5",
     "date-fns": "^2.25.0",
+    "exponential-backoff": "^3.1.1",
     "graphql": "^16.7.1",
     "gray-matter": "^4.0.3",
     "make-plural": "^7.0.0",

--- a/pages/tokens/[id].tsx
+++ b/pages/tokens/[id].tsx
@@ -161,7 +161,7 @@ export default function TokenDetail({ token }: TokenDetailProps) {
 }
 
 export async function getStaticPaths() {
-  const tokenIds = getTokensIds()
+  const tokenIds = await getTokensIds()
 
   return {
     fallback: false,

--- a/pages/tokens/[id].tsx
+++ b/pages/tokens/[id].tsx
@@ -30,6 +30,7 @@ import { TokenDetails } from 'types'
 import { GetStaticProps } from 'next'
 import { ParsedUrlQuery } from 'querystring'
 
+const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
 export interface TokenDetailProps {
   token: TokenDetails
 }
@@ -182,5 +183,6 @@ export const getStaticProps: GetStaticProps<TokenDetailProps> = async ({ params 
     props: {
       token: token,
     },
+    revalidate: DATA_CACHE_TIME_SECONDS,
   }
 }

--- a/pages/tokens/index.tsx
+++ b/pages/tokens/index.tsx
@@ -164,7 +164,7 @@ export default function TokenList({ tokens }: { tokens: TokenInfo[] }) {
 }
 
 export const getStaticProps: GetStaticProps<TokenListProps> = async () => {
-  const tokens = getTokensInfo()
+  const tokens = await getTokensInfo()
 
   return {
     props: {

--- a/pages/tokens/index.tsx
+++ b/pages/tokens/index.tsx
@@ -11,6 +11,8 @@ import { formatUSDPrice } from 'util/formatUSDPrice'
 import { TokenInfo } from 'types'
 import { GetStaticProps } from 'next'
 
+const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
+
 const Wrapper = styled.div`
   --tokenSize: 2.6rem;
   display: flex;
@@ -170,5 +172,6 @@ export const getStaticProps: GetStaticProps<TokenListProps> = async () => {
     props: {
       tokens,
     },
+    revalidate: DATA_CACHE_TIME_SECONDS,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,6 +3207,11 @@ exenv@^1.2.2:
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
   integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
 
+exponential-backoff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"


### PR DESCRIPTION
This PR makes number dynamic.

- The tokens will be loaded from a URL (instead)
- This version will be DYNAMIC, so if the data from that URL changes, it will update the numbers
- It has no performance issue for users (they will see the stale version until new one is ready)
- Fetching the URL has some re-attempting logic


## Next steps
https://github.com/cowprotocol/token-lists already pushes some lists to S3

We should build every hour and consume from S3. 

In any case, this is a temporal patch just to get our of the door. Ideally, https://github.com/cowprotocol/token-lists should be cleaned up (and moved somewhere else?)