### PR TITLE
Add utm handling

### DIFF
--- a/components/Home/index.tsx
+++ b/components/Home/index.tsx
@@ -20,6 +20,7 @@ import SocialList from '@/components/SocialList'
 import Button from '@/components/Button'
 
 import { MetricsData } from 'types'
+import { useUtm } from 'modules/utm'
 
 export interface HomeProps {
   metricsData: MetricsData
@@ -27,7 +28,8 @@ export interface HomeProps {
 }
 
 export default function Home({ metricsData, siteConfigData }: HomeProps) {
-  const { title, descriptionShort, social, url } = siteConfigData
+  const { social, url } = siteConfigData
+  const utm = useUtm() || {}
 
   const scrollToElRef = useRef(null)
 
@@ -38,6 +40,19 @@ export default function Home({ metricsData, siteConfigData }: HomeProps) {
         <SectionContent>
           <div>
             <h1>Better than the best prices</h1>
+            <pre
+              style={{
+                border: '2px solid black',
+                background: 'white',
+                color: 'black',
+                width: '100%',
+                minHeight: '100px',
+                fontSize: '16px',
+                padding: '20px',
+              }}
+            >
+              {JSON.stringify(utm, null, 2)}
+            </pre>
             <SubTitle align={'left'} color={Color.text1} lineHeight={1.4}>
               CoW Protocol finds the lowest price for your trade across all exchanges and aggregators, such as Uniswap
               and 1inch – and protects you from MEV, unlike the others.

--- a/components/Home/index.tsx
+++ b/components/Home/index.tsx
@@ -29,7 +29,6 @@ export interface HomeProps {
 
 export default function Home({ metricsData, siteConfigData }: HomeProps) {
   const { social, url } = siteConfigData
-  const utm = useUtm() || {}
 
   const scrollToElRef = useRef(null)
 
@@ -40,19 +39,6 @@ export default function Home({ metricsData, siteConfigData }: HomeProps) {
         <SectionContent>
           <div>
             <h1>Better than the best prices</h1>
-            <pre
-              style={{
-                border: '2px solid black',
-                background: 'white',
-                color: 'black',
-                width: '100%',
-                minHeight: '100px',
-                fontSize: '16px',
-                padding: '20px',
-              }}
-            >
-              {JSON.stringify(utm, null, 2)}
-            </pre>
             <SubTitle align={'left'} color={Color.text1} lineHeight={1.4}>
               CoW Protocol finds the lowest price for your trade across all exchanges and aggregators, such as Uniswap
               and 1inch – and protects you from MEV, unlike the others.

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router'
 import { CustomLink as CustomLink } from '../CustomLink'
 import { CONFIG } from '@/const/meta'
 import { HEADER_LINKS } from '@/const/menu'
+import { LinkWithUtm } from 'modules/utm'
 
 const LogoImage = '/images/logo.svg'
 const LogoLightImage = '/images/logo-light.svg'
@@ -299,15 +300,16 @@ export default function Header() {
                 <CloseIcon onClick={handleClick} />
               </Menu>
 
-              <Button
-                variant={!inView ? 'small' : 'outline'}
-                minHeight={4.8}
-                fontSize={1.6}
-                href={swapURL}
-                label={'Trade on CoW Swap'}
-                target="_blank"
-                rel="noopener nofollow"
-              />
+              <LinkWithUtm href={swapURL} passHref>
+                <Button
+                  variant={!inView ? 'small' : 'outline'}
+                  minHeight={4.8}
+                  fontSize={1.6}
+                  label={'Trade on CoW Swap'}
+                  target="_blank"
+                  rel="noopener nofollow"
+                />
+              </LinkWithUtm>
               <MenuToggle isLight={isLight} onClick={handleClick} />
             </Content>
           </Wrapper>

--- a/const/meta.ts
+++ b/const/meta.ts
@@ -7,7 +7,7 @@ export const CONFIG = {
   descriptionShort: 'The smartest way to trade',
   url: {
     root: 'https://cow.fi',
-    swap: 'https://swap.cow.fi',
+    swap: 'https://swap.cow.fi/#/1/swap/WETH/DAI?sellAmount=1',
     docs: 'https://docs.cow.fi',
     api: API_BASE_URL + '/mainnet',
     apiDocs: API_BASE_URL + '/docs',

--- a/modules/utm/components.tsx
+++ b/modules/utm/components.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import Link, { LinkProps } from 'next/link'
+import { useRouter } from 'next/router'
+import { useUtm } from 'modules/utm'
+import { addUtmToUrl, hasUtmCodes } from 'modules/utm/utils'
+
+export function LinkWithUtm(p: React.PropsWithChildren<LinkProps>): JSX.Element {
+  const { href, as, children, ...props } = p
+  const utm = useUtm()
+
+  const newHref = useMemo(() => {
+    if (hasUtmCodes(utm) && typeof href === 'string') {
+      return addUtmToUrl(href, utm)
+    }
+    return href
+  }, [utm, href])
+
+  return (
+    <Link href={newHref} as={as} {...props}>
+      {children}
+    </Link>
+  )
+}

--- a/modules/utm/hooks.ts
+++ b/modules/utm/hooks.ts
@@ -2,56 +2,15 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 // import { useLocation, useNavigate } from 'react-router-dom'
-import { NextRouter, useRouter } from 'next/router'
-import { useParams } from 'next/navigation'
+import { useRouter } from 'next/router'
 
 import { utmAtom } from './state'
 import { UtmParams } from './types'
 import { ParsedUrlQuery } from 'querystring'
-
-const UTM_SOURCE_PARAM = 'utm_source'
-const UTM_MEDIUM_PARAM = 'utm_medium'
-const UTM_CAMPAIGN_PARAM = 'utm_campaign'
-const UTM_CONTENT_PARAM = 'utm_content'
-const UTM_TERM_PARAM = 'utm_term'
-
-const ALL_UTM_PARAMS = [UTM_SOURCE_PARAM, UTM_MEDIUM_PARAM, UTM_CAMPAIGN_PARAM, UTM_CONTENT_PARAM, UTM_TERM_PARAM]
-
-function getUtmParams(query: ParsedUrlQuery): UtmParams {
-  const utmSource = (query[UTM_SOURCE_PARAM] as string) || undefined
-  const utmMedium = (query[UTM_MEDIUM_PARAM] as string) || undefined
-  const utmCampaign = (query[UTM_CAMPAIGN_PARAM] as string) || undefined
-  const utmContent = (query[UTM_CONTENT_PARAM] as string) || undefined
-  const utmTerm = (query[UTM_TERM_PARAM] as string) || undefined
-
-  return {
-    utmSource,
-    utmMedium,
-    utmCampaign,
-    utmContent,
-    utmTerm,
-  }
-}
+import { cleanUpParams, getUtmParams, hasUtmCodes } from './utils'
 
 export function useUtm(): UtmParams | undefined {
   return useAtomValue(utmAtom)
-}
-
-function cleanUpParams(router: NextRouter) {
-  let cleanedParams = false
-  const { query } = router
-  ALL_UTM_PARAMS.forEach((param) => {
-    if (query[param]) {
-      delete query[param]
-      cleanedParams = true
-    }
-  })
-
-  if (cleanedParams) {
-    // navigate({ pathname, search: searchParams.toString() }, { replace: true })
-    console.log('UTM init replace', query)
-    router.replace({ pathname: router.pathname, query })
-  }
 }
 
 export function useInitializeUtm(): void {
@@ -65,7 +24,7 @@ export function useInitializeUtm(): void {
   useEffect(
     () => {
       const utm = getUtmParams(router.query)
-      if (utm.utmSource || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmTerm) {
+      if (hasUtmCodes(utm)) {
         // Only overrides the UTM if the URL includes at least one UTM param
         setUtm(utm)
       }

--- a/modules/utm/hooks.ts
+++ b/modules/utm/hooks.ts
@@ -1,0 +1,80 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { useEffect } from 'react'
+
+// import { useLocation, useNavigate } from 'react-router-dom'
+import { NextRouter, useRouter } from 'next/router'
+import { useParams } from 'next/navigation'
+
+import { utmAtom } from './state'
+import { UtmParams } from './types'
+import { ParsedUrlQuery } from 'querystring'
+
+const UTM_SOURCE_PARAM = 'utm_source'
+const UTM_MEDIUM_PARAM = 'utm_medium'
+const UTM_CAMPAIGN_PARAM = 'utm_campaign'
+const UTM_CONTENT_PARAM = 'utm_content'
+const UTM_TERM_PARAM = 'utm_term'
+
+const ALL_UTM_PARAMS = [UTM_SOURCE_PARAM, UTM_MEDIUM_PARAM, UTM_CAMPAIGN_PARAM, UTM_CONTENT_PARAM, UTM_TERM_PARAM]
+
+function getUtmParams(query: ParsedUrlQuery): UtmParams {
+  const utmSource = (query[UTM_SOURCE_PARAM] as string) || undefined
+  const utmMedium = (query[UTM_MEDIUM_PARAM] as string) || undefined
+  const utmCampaign = (query[UTM_CAMPAIGN_PARAM] as string) || undefined
+  const utmContent = (query[UTM_CONTENT_PARAM] as string) || undefined
+  const utmTerm = (query[UTM_TERM_PARAM] as string) || undefined
+
+  return {
+    utmSource,
+    utmMedium,
+    utmCampaign,
+    utmContent,
+    utmTerm,
+  }
+}
+
+export function useUtm(): UtmParams | undefined {
+  return useAtomValue(utmAtom)
+}
+
+function cleanUpParams(router: NextRouter) {
+  let cleanedParams = false
+  const { query } = router
+  ALL_UTM_PARAMS.forEach((param) => {
+    if (query[param]) {
+      delete query[param]
+      cleanedParams = true
+    }
+  })
+
+  if (cleanedParams) {
+    // navigate({ pathname, search: searchParams.toString() }, { replace: true })
+    console.log('UTM init replace', query)
+    router.replace({ pathname: router.pathname, query })
+  }
+}
+
+export function useInitializeUtm(): void {
+  const router = useRouter()
+  // const navigate = useNavigate()
+  // const { search, pathname } = useLocation()
+
+  // get atom setter
+  const setUtm = useSetAtom(utmAtom)
+
+  useEffect(
+    () => {
+      const utm = getUtmParams(router.query)
+      if (utm.utmSource || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmTerm) {
+        // Only overrides the UTM if the URL includes at least one UTM param
+        setUtm(utm)
+      }
+
+      // Clear params from URL and redirect
+      cleanUpParams(router)
+    },
+    // No dependencies: It only needs to be initialized once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+}

--- a/modules/utm/index.ts
+++ b/modules/utm/index.ts
@@ -1,0 +1,2 @@
+export { useInitializeUtm, useUtm } from './hooks'
+export type { UtmParams } from './types'

--- a/modules/utm/index.ts
+++ b/modules/utm/index.ts
@@ -1,2 +1,3 @@
 export { useInitializeUtm, useUtm } from './hooks'
+export { LinkWithUtm } from './components'
 export type { UtmParams } from './types'

--- a/modules/utm/state.ts
+++ b/modules/utm/state.ts
@@ -1,0 +1,5 @@
+import { atomWithStorage } from 'jotai/utils'
+
+import { UtmParams } from './types'
+
+export const utmAtom = atomWithStorage<UtmParams | undefined>('utm-atom:v1', undefined)

--- a/modules/utm/types.ts
+++ b/modules/utm/types.ts
@@ -1,0 +1,7 @@
+export interface UtmParams {
+  utmSource?: string
+  utmMedium?: string
+  utmCampaign?: string
+  utmContent?: string
+  utmTerm?: string
+}

--- a/modules/utm/utils.ts
+++ b/modules/utm/utils.ts
@@ -73,7 +73,9 @@ export function addUtmToUrl(href: string, utm: UtmParams): string {
     url.searchParams.set(UTM_TERM_PARAM, utm.utmTerm)
   }
 
-  console.log('UTM addUtmToUrl', url)
+  const [hash = '', params = ''] = url.hash.split('?')
+  const searchParams = (url.search && url.search.slice(1)) || ''
+  const urlParams = params || searchParams ? `?${params}&${searchParams}` : ''
 
-  return url.origin + url.hash + url.search
+  return url.origin + hash + urlParams
 }

--- a/modules/utm/utils.ts
+++ b/modules/utm/utils.ts
@@ -1,0 +1,79 @@
+const UTM_SOURCE_PARAM = 'utm_source'
+const UTM_MEDIUM_PARAM = 'utm_medium'
+const UTM_CAMPAIGN_PARAM = 'utm_campaign'
+const UTM_CONTENT_PARAM = 'utm_content'
+const UTM_TERM_PARAM = 'utm_term'
+
+const ALL_UTM_PARAMS = [UTM_SOURCE_PARAM, UTM_MEDIUM_PARAM, UTM_CAMPAIGN_PARAM, UTM_CONTENT_PARAM, UTM_TERM_PARAM]
+
+// import { useLocation, useNavigate } from 'react-router-dom'
+import { NextRouter } from 'next/router'
+import { UtmParams } from './types'
+import { ParsedUrlQuery } from 'querystring'
+
+export function getUtmParams(query: ParsedUrlQuery): UtmParams {
+  const utmSource = (query[UTM_SOURCE_PARAM] as string) || undefined
+  const utmMedium = (query[UTM_MEDIUM_PARAM] as string) || undefined
+  const utmCampaign = (query[UTM_CAMPAIGN_PARAM] as string) || undefined
+  const utmContent = (query[UTM_CONTENT_PARAM] as string) || undefined
+  const utmTerm = (query[UTM_TERM_PARAM] as string) || undefined
+
+  return {
+    utmSource,
+    utmMedium,
+    utmCampaign,
+    utmContent,
+    utmTerm,
+  }
+}
+
+export function cleanUpParams(router: NextRouter) {
+  let cleanedParams = false
+  const { query } = router
+  ALL_UTM_PARAMS.forEach((param) => {
+    if (query[param]) {
+      delete query[param]
+      cleanedParams = true
+    }
+  })
+
+  if (cleanedParams) {
+    // navigate({ pathname, search: searchParams.toString() }, { replace: true })
+    console.log('UTM init replace', query)
+    router.replace({ pathname: router.pathname, query })
+  }
+}
+
+export function hasUtmCodes(utm: UtmParams | undefined): boolean {
+  if (!utm) return false
+
+  return !!(utm.utmSource || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmTerm)
+}
+
+export function addUtmToUrl(href: string, utm: UtmParams): string {
+  const url = new URL(href, window.location.origin)
+
+  if (utm.utmCampaign) {
+    url.searchParams.set(UTM_CAMPAIGN_PARAM, utm.utmCampaign)
+  }
+
+  if (utm.utmContent) {
+    url.searchParams.set(UTM_CONTENT_PARAM, utm.utmContent)
+  }
+
+  if (utm.utmMedium) {
+    url.searchParams.set(UTM_MEDIUM_PARAM, utm.utmMedium)
+  }
+
+  if (utm.utmSource) {
+    url.searchParams.set(UTM_SOURCE_PARAM, utm.utmSource)
+  }
+
+  if (utm.utmTerm) {
+    url.searchParams.set(UTM_TERM_PARAM, utm.utmTerm)
+  }
+
+  console.log('UTM addUtmToUrl', url)
+
+  return url.origin + url.hash + url.search
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "exponential-backoff": "^3.1.1",
     "graphql": "^16.7.1",
     "gray-matter": "^4.0.3",
+    "jotai": "^2.2.2",
     "make-plural": "^7.0.0",
     "markdown-to-jsx": "^7.1.5",
     "next": "latest",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,9 +6,12 @@ import { CONFIG } from '@/const/meta'
 import { Analytics } from '@/components/Analytics'
 import { ApolloProvider } from '@apollo/client'
 import { apolloClient } from 'services/uniswap-price/apollo-client'
+import { useInitializeUtm } from 'modules/utm'
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props
+  useInitializeUtm()
+
   return (
     <>
       <Head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,22 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^1.1.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
+  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
 "@emotion/stylis@^0.8.4":
   version "0.8.5"
@@ -4131,6 +4143,11 @@ jest-worker@27.0.0-next.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jotai@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.2.2.tgz#1e181789dcc01ced8240b18b95d9fa10169f9366"
+  integrity sha512-Cn8hnBg1sc5ppFwEgVGTfMR5WSM0hbAasd/bdAwIwTaum0j3OUPqBSC4tyk3jtB95vicML+RRWgKFOn6gtfN0A==
+
 js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
@@ -6192,6 +6209,22 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+styled-components@^5:
+  version "5.3.11"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.11.tgz#9fda7bf1108e39bf3f3e612fcc18170dedcd57a8"
+  integrity sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^1.1.0"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1.12.0"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
 
 styled-components@^5.3.3:
   version "5.3.3"


### PR DESCRIPTION
This PR adds a way to propagate UTM params to other sites (like CoW Swap) 🎉

![image](https://github.com/cowprotocol/cow-fi/assets/2352112/10fb5e38-603f-4a69-a472-21f34be687aa)


It will:
- Persist in local storage when the user arrives with UTM information
- Delete the UTM from the URL (so is not visible after it is consumed)
- Creates a `LinkWithUtm` which works as a `<Link />` but it will handle the UTM additions
- Creates a `useUtm()` hook that will return the codes
- Adds the special button in `Trade on CoW Swap` button. Even if user don't use it on their first visit, because we remember their UTM codes, we will use it next time
- Added to the footer


This is how you can use the component:

![image](https://github.com/cowprotocol/cow-fi/assets/2352112/f033e608-ca48-46fc-8ca7-8682fb573d50)


# Test

1. Use the test URL
2. Append in the URL `utm_source=github&utm_medium=web&utm_campaign=test-utm-code&utm_content=pr&utm_term=coincidence+of+wants`
3. Click on `Trade on CoW Swap` in the top right corner
4. It will navigate to CoW Swap with the UTM codes