### PR TITLE
Add UTM codes in footer

### DIFF
--- a/components/CustomLink.tsx
+++ b/components/CustomLink.tsx
@@ -1,26 +1,28 @@
+import { LinkWithUtm } from 'modules/utm'
 import Link from 'next/link'
 
-type CustomLinkType = 'internal' | 'external'| 'external_untrusted'
+type CustomLinkType = 'internal' | 'external' | 'external_untrusted'
 
 export interface CustomLinkProps {
   url: string
-  label: string, // TODO: label
+  label: string // TODO: label
   type?: CustomLinkType
+  utm?: boolean
   onClick?: () => void
 }
 
-function getAnchorRel(type?: CustomLinkType): { target?: string, rel?: string } {
+function getAnchorRel(type?: CustomLinkType): { target?: string; rel?: string } {
   switch (type) {
     case 'external_untrusted':
       return {
         target: '_blank',
-        rel: 'noopener noreferrer nofollow'
+        rel: 'noopener noreferrer nofollow',
       }
 
     case 'external':
       return {
         target: '_blank',
-        rel: 'noopener'
+        rel: 'noopener',
       }
   }
 
@@ -28,16 +30,14 @@ function getAnchorRel(type?: CustomLinkType): { target?: string, rel?: string } 
 }
 
 export function CustomLink(props: CustomLinkProps) {
-  const { url, label: title, type='internal', onClick } = props
+  const { url, label: title, type = 'internal', onClick, utm } = props
   const { rel, target } = getAnchorRel(type)
+  const LinkComponent = utm ? LinkWithUtm : Link
   return (
-    <Link href={url}>
-      <a 
-        target={target} 
-        rel={rel}
-        onClick={onClick}>
-          {title}
+    <LinkComponent href={url} passHref>
+      <a target={target} rel={rel} onClick={onClick}>
+        {title}
       </a>
-    </Link>
+    </LinkComponent>
   )
 }

--- a/const/menu.ts
+++ b/const/menu.ts
@@ -24,29 +24,29 @@ export const FOOTER_LINK_GROUPS: FooterLinkGroup[] = [
       { label: 'Analytics', url: url.analytics, type: 'external' },
       { label: 'Careers', url: '/careers' },
       { label: 'Grants', url: url.grants, type: 'external' },
-      { label: 'Explorer', url: url.explorer, type: 'external' },
+      { label: 'Explorer', url: url.explorer, type: 'external', utm: true },
     ],
   },
   {
     label: 'About',
     links: [
       { label: 'CoW Protocol', url: '/#about' },
-      { label: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external' },
-      { label: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external' },
+      { label: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external', utm: true },
+      { label: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external', utm: true },
       {
         label: 'Brand Kit',
         url: 'https://cownation.notion.site/CoW-DAO-Brand-Kit-fe70d51a39df4229b7912cb7af3eb320',
         type: 'external',
       },
-      { label: 'Terms and Conditions', url: 'https://swap.cow.fi/#/terms-and-conditions', type: 'external' },
-      { label: 'Privacy Policy', url: 'https://swap.cow.fi/#/privacy-policy', type: 'external' },
-      { label: 'Cookie Policy', url: 'https://swap.cow.fi/#/cookie-policy', type: 'external' },
+      { label: 'Terms and Conditions', url: 'https://swap.cow.fi/#/terms-and-conditions', type: 'external', utm: true },
+      { label: 'Privacy Policy', url: 'https://swap.cow.fi/#/privacy-policy', type: 'external', utm: true },
+      { label: 'Cookie Policy', url: 'https://swap.cow.fi/#/cookie-policy', type: 'external', utm: true },
     ],
   },
   {
     label: 'Developers',
     links: [
-      { label: 'Documentation', url: url.docs, type: 'external' },
+      { label: 'Documentation', url: url.docs, type: 'external', utm: true },
       { label: 'API Documentation', url: url.apiDocs, type: 'external' },
       { label: 'GitHub', url: social.github.url, type: 'external' },
       {


### PR DESCRIPTION
Add UTM codes in footer


![image](https://github.com/cowprotocol/cow-fi/assets/2352112/a5cc0240-866d-4b7d-a09d-c2a41513fb56)


This PR adds support for UTM in our custom link (see https://github.com/cowprotocol/cow-fi/blob/bc886131f31061509b00c363a74baa7c06b9efd2/components/CustomLink.tsx#L10) 


Depending on the type of link we will add the UTM codes or not: https://github.com/cowprotocol/cow-fi/blob/bc886131f31061509b00c363a74baa7c06b9efd2/components/CustomLink.tsx#L35


Now the links that require the codes can include this boolean flag: https://github.com/cowprotocol/cow-fi/blob/bc886131f31061509b00c363a74baa7c06b9efd2/const/menu.ts#L27