### PR TITLE
Default utm

### DIFF
--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -300,7 +300,15 @@ export default function Header() {
                 <CloseIcon onClick={handleClick} />
               </Menu>
 
-              <LinkWithUtm href={swapURL} passHref>
+              <LinkWithUtm
+                defaultUtm={{
+                  utmSource: CONFIG.utm.source,
+                  utmMedium: CONFIG.utm.medium,
+                  utmContent: 'trade-on-cow-swap-button',
+                }}
+                href={swapURL}
+                passHref
+              >
                 <Button
                   variant={!inView ? 'small' : 'outline'}
                   minHeight={4.8}

--- a/components/SwapWidget.tsx
+++ b/components/SwapWidget.tsx
@@ -4,6 +4,7 @@ import { Color } from 'styles/variables'
 import Button from '@/components/Button'
 import { transparentize } from 'polished'
 import { CONFIG } from '@/const/meta'
+import { LinkWithUtm } from 'modules/utm'
 
 type TabProps = {
   active: boolean
@@ -203,9 +204,6 @@ const NETWORK_MAP: { [key: string]: string } = {
 const WXDAI = '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d'
 const WETH = ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1']
 
-const toUtmParams = (tokenId: string) =>
-  `utm_source=${CONFIG.utm.source}&utm_medium=${CONFIG.utm.medium}&utm_content=swap-widget-token__${encodeURI(tokenId)}`
-
 export const SwapWidget = ({ tokenId, tokenSymbol, tokenImage, platforms }: SwapWidgetProps) => {
   const [activeTab, setActiveTab] = useState('Buy')
   const [network, setNetwork] = useState<string | null>(null)
@@ -266,8 +264,7 @@ export const SwapWidget = ({ tokenId, tokenSymbol, tokenImage, platforms }: Swap
         }
       }
 
-      const utmParams = toUtmParams(tokenId)
-      const url = `https://swap.cow.fi/#/${networkId}/swap/${sellToken}/${buyToken}?${activeTab.toLowerCase()}Amount=${amount}&${utmParams}`
+      const url = `https://swap.cow.fi/#/${networkId}/swap/${sellToken}/${buyToken}?${activeTab.toLowerCase()}Amount=${amount}`
       return url
     } else {
       return '#'
@@ -323,14 +320,17 @@ export const SwapWidget = ({ tokenId, tokenSymbol, tokenImage, platforms }: Swap
         </div>
       </InputLabel>
 
-      <Button
+      <LinkWithUtm
+        defaultUtm={{
+          utmSource: CONFIG.utm.source,
+          utmMedium: CONFIG.utm.medium,
+          utmContent: 'utm_content=swap-widget-token__' + encodeURI(tokenId),
+        }}
         href={onSwap()}
-        target="_blank"
-        rel="noreferrer"
-        label={`Swap ${tokenSymbol}`}
-        fontSize={1.6}
-        minHeight={4.2}
-      />
+        passHref
+      >
+        <Button target="_blank" rel="noreferrer" label={`Swap ${tokenSymbol}`} fontSize={1.6} minHeight={4.2} />
+      </LinkWithUtm>
     </Wrapper>
   )
 }

--- a/modules/utm/components.tsx
+++ b/modules/utm/components.tsx
@@ -1,19 +1,24 @@
 import { useMemo } from 'react'
 import Link, { LinkProps } from 'next/link'
 import { useRouter } from 'next/router'
-import { useUtm } from 'modules/utm'
+import { UtmParams, useUtm } from 'modules/utm'
 import { addUtmToUrl, hasUtmCodes } from 'modules/utm/utils'
 
-export function LinkWithUtm(p: React.PropsWithChildren<LinkProps>): JSX.Element {
-  const { href, as, children, ...props } = p
+interface LinkWithUtmProps extends React.PropsWithChildren<LinkProps> {
+  defaultUtm?: UtmParams
+}
+
+export function LinkWithUtm(p: LinkWithUtmProps): JSX.Element {
+  const { href, as, children, defaultUtm, ...props } = p
   const utm = useUtm()
 
   const newHref = useMemo(() => {
-    if (hasUtmCodes(utm) && typeof href === 'string') {
-      return addUtmToUrl(href, utm)
+    const utmAux = utm || defaultUtm
+    if (hasUtmCodes(utmAux) && typeof href === 'string') {
+      return addUtmToUrl(href, utmAux)
     }
     return href
-  }, [utm, href])
+  }, [utm, defaultUtm, href])
 
   return (
     <Link href={newHref} as={as} {...props}>

--- a/modules/utm/components.tsx
+++ b/modules/utm/components.tsx
@@ -13,8 +13,8 @@ export function LinkWithUtm(p: LinkWithUtmProps): JSX.Element {
   const utm = useUtm()
 
   const newHref = useMemo(() => {
-    const utmAux = utm || defaultUtm
-    if (hasUtmCodes(utmAux) && typeof href === 'string') {
+    const utmAux = getUtm(utm, defaultUtm)
+    if (utmAux && typeof href === 'string') {
       return addUtmToUrl(href, utmAux)
     }
     return href
@@ -25,4 +25,14 @@ export function LinkWithUtm(p: LinkWithUtmProps): JSX.Element {
       {children}
     </Link>
   )
+}
+
+function getUtm(...utms: UtmParams[]): UtmParams | null {
+  for (const utm of utms) {
+    if (hasUtmCodes(utm)) {
+      return utm
+    }
+  }
+
+  return null
 }

--- a/modules/utm/utils.ts
+++ b/modules/utm/utils.ts
@@ -51,6 +51,10 @@ export function hasUtmCodes(utm: UtmParams | undefined): boolean {
 }
 
 export function addUtmToUrl(href: string, utm: UtmParams): string {
+  if (typeof window === 'undefined') {
+    return href
+  }
+
   const url = new URL(href, window.location.origin)
 
   if (utm.utmCampaign) {


### PR DESCRIPTION
Adds support for `defaultUtm` param in the `LinkWithUtm`

This will allow to use our own UTM if no other UTM codes are present. This way, the UTM code is respected, and if there's none, you have a chance to set one

It adds a default for:
- The widget in the tokens page
- The button in the header to trade in cowswap


![image](https://github.com/cowprotocol/cow-fi/assets/2352112/c1e8e809-37f9-44cb-a318-6d8267f36e4b)
