### PR TITLE
Add utm default everywhere + Fix issues

### DIFF
--- a/components/CustomLink.tsx
+++ b/components/CustomLink.tsx
@@ -1,4 +1,5 @@
-import { LinkWithUtm } from 'modules/utm'
+import { CONFIG } from '@/const/meta'
+import { LinkWithUtm, UtmParams } from 'modules/utm'
 import Link from 'next/link'
 
 type CustomLinkType = 'internal' | 'external' | 'external_untrusted'
@@ -7,7 +8,7 @@ export interface CustomLinkProps {
   url: string
   label: string // TODO: label
   type?: CustomLinkType
-  utm?: boolean
+  utmContent?: string
   onClick?: () => void
 }
 
@@ -30,11 +31,13 @@ function getAnchorRel(type?: CustomLinkType): { target?: string; rel?: string } 
 }
 
 export function CustomLink(props: CustomLinkProps) {
-  const { url, label: title, type = 'internal', onClick, utm } = props
+  const { url, label: title, type = 'internal', onClick, utmContent } = props
   const { rel, target } = getAnchorRel(type)
-  const LinkComponent = utm ? LinkWithUtm : Link
+
+  const [LinkComponent, defaultUtm] = utmContent ? [LinkWithUtm, { ...CONFIG.utm, utmContent }] : [Link, undefined]
+
   return (
-    <LinkComponent href={url} passHref>
+    <LinkComponent href={url} passHref defaultUtm={defaultUtm}>
       <a target={target} rel={rel} onClick={onClick}>
         {title}
       </a>

--- a/components/Home/index.tsx
+++ b/components/Home/index.tsx
@@ -20,7 +20,7 @@ import SocialList from '@/components/SocialList'
 import Button from '@/components/Button'
 
 import { MetricsData } from 'types'
-import { useUtm } from 'modules/utm'
+import { LinkWithUtm } from 'modules/utm'
 
 export interface HomeProps {
   metricsData: MetricsData
@@ -45,7 +45,9 @@ export default function Home({ metricsData, siteConfigData }: HomeProps) {
             </SubTitle>
 
             <ButtonWrapper>
-              <Button paddingLR={4.2} href={url.swap} target="_blank" rel="noopener nofollow" label="Start trading" />
+              <LinkWithUtm href={url.swap} defaultUtm={{ ...CONFIG.utm, utmContent: 'landing-cta-button' }} passHref>
+                <Button paddingLR={4.2} target="_blank" rel="noopener nofollow" label="Start trading" />
+              </LinkWithUtm>
               <Button paddingLR={4.2} variant="text" href={'/#developers'} label="Start building" />
             </ButtonWrapper>
           </div>

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -303,7 +303,7 @@ export default function Header() {
               <LinkWithUtm
                 defaultUtm={{
                   ...CONFIG.utm,
-                  utmContent: 'trade-on-cow-swap-button',
+                  utmContent: 'header-cta-button',
                 }}
                 href={swapURL}
                 passHref

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -302,8 +302,7 @@ export default function Header() {
 
               <LinkWithUtm
                 defaultUtm={{
-                  utmSource: CONFIG.utm.source,
-                  utmMedium: CONFIG.utm.medium,
+                  ...CONFIG.utm,
                   utmContent: 'trade-on-cow-swap-button',
                 }}
                 href={swapURL}

--- a/components/SwapWidget.tsx
+++ b/components/SwapWidget.tsx
@@ -322,8 +322,7 @@ export const SwapWidget = ({ tokenId, tokenSymbol, tokenImage, platforms }: Swap
 
       <LinkWithUtm
         defaultUtm={{
-          utmSource: CONFIG.utm.source,
-          utmMedium: CONFIG.utm.medium,
+          ...CONFIG.utm,
           utmContent: 'utm_content=swap-widget-token__' + encodeURI(tokenId),
         }}
         href={onSwap()}

--- a/const/menu.ts
+++ b/const/menu.ts
@@ -14,6 +14,8 @@ export const HEADER_LINKS: CustomLinkProps[] = [
   { label: 'Careers', url: '/careers' },
 ]
 
+const utmContent = 'footer-link'
+
 export const FOOTER_LINK_GROUPS: FooterLinkGroup[] = [
   {
     label: 'CoW Protocol',
@@ -24,29 +26,34 @@ export const FOOTER_LINK_GROUPS: FooterLinkGroup[] = [
       { label: 'Analytics', url: url.analytics, type: 'external' },
       { label: 'Careers', url: '/careers' },
       { label: 'Grants', url: url.grants, type: 'external' },
-      { label: 'Explorer', url: url.explorer, type: 'external', utm: true },
+      { label: 'Explorer', url: url.explorer, type: 'external', utmContent },
     ],
   },
   {
     label: 'About',
     links: [
       { label: 'CoW Protocol', url: '/#about' },
-      { label: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external', utm: true },
-      { label: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external', utm: true },
+      { label: 'CoW Swap', url: 'https://swap.cow.fi/#/about', type: 'external', utmContent },
+      { label: 'CoW Swap FAQ', url: 'https://swap.cow.fi/#/faq', type: 'external', utmContent },
       {
         label: 'Brand Kit',
         url: 'https://cownation.notion.site/CoW-DAO-Brand-Kit-fe70d51a39df4229b7912cb7af3eb320',
         type: 'external',
       },
-      { label: 'Terms and Conditions', url: 'https://swap.cow.fi/#/terms-and-conditions', type: 'external', utm: true },
-      { label: 'Privacy Policy', url: 'https://swap.cow.fi/#/privacy-policy', type: 'external', utm: true },
-      { label: 'Cookie Policy', url: 'https://swap.cow.fi/#/cookie-policy', type: 'external', utm: true },
+      {
+        label: 'Terms and Conditions',
+        url: 'https://swap.cow.fi/#/terms-and-conditions',
+        type: 'external',
+        utmContent,
+      },
+      { label: 'Privacy Policy', url: 'https://swap.cow.fi/#/privacy-policy', type: 'external', utmContent },
+      { label: 'Cookie Policy', url: 'https://swap.cow.fi/#/cookie-policy', type: 'external', utmContent },
     ],
   },
   {
     label: 'Developers',
     links: [
-      { label: 'Documentation', url: url.docs, type: 'external', utm: true },
+      { label: 'Documentation', url: url.docs, type: 'external', utmContent },
       { label: 'API Documentation', url: url.apiDocs, type: 'external' },
       { label: 'GitHub', url: social.github.url, type: 'external' },
       {

--- a/const/meta.ts
+++ b/const/meta.ts
@@ -26,8 +26,8 @@ export const CONFIG = {
     forum: { label: 'Forum', url: 'https://forum.cow.fi/' },
   },
   utm: {
-    source: 'cow.fi',
-    medium: 'web',
+    utmSource: 'cow.fi',
+    utmMedium: 'web',
   },
   tokenDisclaimer:
     'IMPORTANT DISCLAIMER: The information presented on the Interface, including hyperlinked sites, associated applications, forums, blogs, social media accounts, and other platforms, serves as general information sourced from third-party providers. We want to emphasise that we do not provide any warranties regarding the accuracy or up-to-dateness of the content. None of the content should be interpreted as financial, tax, legal, or any other type of advice. Your use or reliance on the content is entirely at your own discretion and risk. Before making any decisions, it is crucial that you undertake your own research, review, analysis, and verification of our content. Trading carries significant risks and can result in substantial losses, so it is advisable to consult your own legal, financial, tax, or other professional advisors prior to making any decisions. None of the content on the Interface is intended as a solicitation or offer.',

--- a/modules/utm/components.tsx
+++ b/modules/utm/components.tsx
@@ -5,7 +5,7 @@ import { UtmParams, useUtm } from 'modules/utm'
 import { addUtmToUrl, hasUtmCodes } from 'modules/utm/utils'
 
 interface LinkWithUtmProps extends React.PropsWithChildren<LinkProps> {
-  defaultUtm?: UtmParams
+  defaultUtm: UtmParams
 }
 
 export function LinkWithUtm(p: LinkWithUtmProps): JSX.Element {

--- a/modules/utm/components.tsx
+++ b/modules/utm/components.tsx
@@ -3,6 +3,7 @@ import Link, { LinkProps } from 'next/link'
 import { useRouter } from 'next/router'
 import { UtmParams, useUtm } from 'modules/utm'
 import { addUtmToUrl, hasUtmCodes } from 'modules/utm/utils'
+import { CONFIG } from '@/const/meta'
 
 interface LinkWithUtmProps extends React.PropsWithChildren<LinkProps> {
   defaultUtm: UtmParams

--- a/modules/utm/hooks.ts
+++ b/modules/utm/hooks.ts
@@ -1,12 +1,10 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
-// import { useLocation, useNavigate } from 'react-router-dom'
 import { useRouter } from 'next/router'
 
 import { utmAtom } from './state'
 import { UtmParams } from './types'
-import { ParsedUrlQuery } from 'querystring'
 import { cleanUpParams, getUtmParams, hasUtmCodes } from './utils'
 
 export function useUtm(): UtmParams | undefined {
@@ -15,25 +13,18 @@ export function useUtm(): UtmParams | undefined {
 
 export function useInitializeUtm(): void {
   const router = useRouter()
-  // const navigate = useNavigate()
-  // const { search, pathname } = useLocation()
 
   // get atom setter
   const setUtm = useSetAtom(utmAtom)
 
-  useEffect(
-    () => {
-      const utm = getUtmParams(router.query)
-      if (hasUtmCodes(utm)) {
-        // Only overrides the UTM if the URL includes at least one UTM param
-        setUtm(utm)
-      }
+  useEffect(() => {
+    const utm = getUtmParams(router.query)
+    if (hasUtmCodes(utm)) {
+      // Only overrides the UTM if the URL includes at least one UTM param
+      setUtm(utm)
+    }
 
-      // Clear params from URL and redirect
-      cleanUpParams(router)
-    },
-    // No dependencies: It only needs to be initialized once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
+    // Clear params from URL and redirect
+    cleanUpParams(router)
+  }, [router, setUtm])
 }

--- a/modules/utm/utils.ts
+++ b/modules/utm/utils.ts
@@ -38,8 +38,6 @@ export function cleanUpParams(router: NextRouter) {
   })
 
   if (cleanedParams) {
-    // navigate({ pathname, search: searchParams.toString() }, { replace: true })
-    console.log('UTM init replace', query)
     router.replace({ pathname: router.pathname, query })
   }
 }

--- a/modules/utm/utils.ts
+++ b/modules/utm/utils.ts
@@ -10,6 +10,7 @@ const ALL_UTM_PARAMS = [UTM_SOURCE_PARAM, UTM_MEDIUM_PARAM, UTM_CAMPAIGN_PARAM, 
 import { NextRouter } from 'next/router'
 import { UtmParams } from './types'
 import { ParsedUrlQuery } from 'querystring'
+import { CONFIG } from '@/const/meta'
 
 export function getUtmParams(query: ParsedUrlQuery): UtmParams {
   const utmSource = (query[UTM_SOURCE_PARAM] as string) || undefined
@@ -49,7 +50,8 @@ export function hasUtmCodes(utm: UtmParams | undefined): boolean {
 }
 
 export function addUtmToUrl(href: string, utm: UtmParams): string {
-  const url = new URL(href)
+  const origin = typeof window !== 'undefined' ? window.location.origin : CONFIG.url.root
+  const url = new URL(href, origin)
 
   if (utm.utmCampaign) {
     url.searchParams.set(UTM_CAMPAIGN_PARAM, utm.utmCampaign)

--- a/modules/utm/utils.ts
+++ b/modules/utm/utils.ts
@@ -49,11 +49,7 @@ export function hasUtmCodes(utm: UtmParams | undefined): boolean {
 }
 
 export function addUtmToUrl(href: string, utm: UtmParams): string {
-  if (typeof window === 'undefined') {
-    return href
-  }
-
-  const url = new URL(href, window.location.origin)
+  const url = new URL(href)
 
   if (utm.utmCampaign) {
     url.searchParams.set(UTM_CAMPAIGN_PARAM, utm.utmCampaign)


### PR DESCRIPTION
# Description
This PR makes sure that if UTM codes are present when you arrive to cow.fi, they will be consumed and taken into account. See https://www.notion.so/cownation/Create-UTM-codes-for-on-chain-analytics-cd1ec4ce33964da48a374c8d17b00913?pvs=4 

If the user doesn't arrive with UTM codes, we will still use some default ones to navigate to CoW Swap.

The UTM codes are consumed from the URL (disappear), and from that moment on, it will add to the relevant links the UTM codes (see test instructions for details on which links)

## Fix Issues
Closes #110 and #109

## Renamed the `utmContent` name in the header button
Now its's called `header-cta-button`

![image](https://github.com/cowprotocol/cow-fi/assets/2352112/e63a79ce-8b67-40e5-9e95-5babfe9861a2)


## Added UTM codes to main CTA in the landing

![image](https://github.com/cowprotocol/cow-fi/assets/2352112/85a72fbb-b6b1-49c1-a4d1-4322d5e30ba3)



## Technical notes
Now the `LinkWithUtm` forces you to define a default UTM

## Fixed issue with server side rendering
🙈 I found out why sometimes the link was not being displayed. 
It was basically cause the component was rendered in the server, and there there's no window. If there's no window, we were not handling the URL logic (easy to see why in the code changes)

## Fixed issue with the consumption of the UTM params of the URL
There was a bug because the hook that is responsible of getting the UTM from the URL and setting the atom was not being re-rendered (because it needed to depend on the router)

Also a silly mistake!

# Test

1. Remove any local storage UTM code you might have
2. verify the defaults are working:
   - Check some of the footer links have it
   - Check the CTA button in the landing
   - Check the CTA button in the header
   - Check the widget
3. Navigate to https://cowfi-git-add-utm-default-everywhere-cowswap.vercel.app/?utm_source=github&utm_medium=web&utm_campaign=test-utm-code&utm_content=pr&utm_term=coincidence+of+wants
4. Repeat the same tests as (2) but checking now it uses the codes we got from the URL


