### PR TITLE
Fix networkchange widget

### DIFF
--- a/components/SwapWidget.tsx
+++ b/components/SwapWidget.tsx
@@ -292,13 +292,13 @@ export const SwapWidget = ({ tokenId, tokenSymbol, tokenImage, platforms }: Swap
         </DropdownHeader>
         {isOpen && (
           <DropdownBody>
-            {platforms.ethereum.contractAddress && (
+            {platforms.ethereum && platforms.ethereum.contractAddress && (
               <DropdownOption onClick={() => handleSelect('ethereum')}>
                 <img src="/images/ethereum.svg" alt="Ethereum" />
                 Ethereum
               </DropdownOption>
             )}
-            {platforms.xdai.contractAddress && (
+            {platforms.xdai && platforms.xdai.contractAddress && (
               <DropdownOption onClick={() => handleSelect('xdai')}>
                 <img src="/images/gnosis-chain.svg" alt="Gnosis Chain" />
                 Gnosis Chain

--- a/components/SwapWidget.tsx
+++ b/components/SwapWidget.tsx
@@ -292,13 +292,13 @@ export const SwapWidget = ({ tokenId, tokenSymbol, tokenImage, platforms }: Swap
         </DropdownHeader>
         {isOpen && (
           <DropdownBody>
-            {platforms.ethereum && platforms.ethereum.contractAddress && (
+            {platforms?.ethereum?.contractAddress && (
               <DropdownOption onClick={() => handleSelect('ethereum')}>
                 <img src="/images/ethereum.svg" alt="Ethereum" />
                 Ethereum
               </DropdownOption>
             )}
-            {platforms.xdai && platforms.xdai.contractAddress && (
+            {platforms?.xdai?.contractAddress && (
               <DropdownOption onClick={() => handleSelect('xdai')}>
                 <img src="/images/gnosis-chain.svg" alt="Gnosis Chain" />
                 Gnosis Chain


### PR DESCRIPTION
- Fixes a reported issue by @alfetopito where on some tokens like http://localhost:3000/tokens/rocket-pool on switch of the network (in the widget) it would crash, because that network is not available.
- The fix involves only adding networks as an option which are actually available.... (make sense 🐞 )