### PR TITLE
Add blog page and post page

### DIFF
--- a/const/menu.ts
+++ b/const/menu.ts
@@ -9,6 +9,7 @@ export interface FooterLinkGroup {
 
 export const HEADER_LINKS: CustomLinkProps[] = [
   { label: 'DAOs', url: url.daos },
+  { label: 'Blog', url: '/blog' },
   { label: 'Widget', url: url.widget },
   { label: 'CoW AMM', url: url.cowamm },
   { label: 'Swag', url: url.swag },

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,0 +1,45 @@
+import Layout from '@/components/Layout'
+import { getTokensInfo } from 'services/tokens'
+import { TokenInfo } from 'types'
+import { GetStaticProps } from 'next'
+import Head from 'next/head'
+import { TokenList, TokenListProps } from '@/components/TokensList'
+import { CONFIG } from '@/const/meta'
+import { Article, getArticles } from 'services/blog'
+
+const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
+
+export interface BlogProps {
+  articles: Article[]
+}
+
+export default function BlogPage({ articles }: BlogProps) {
+  return (
+    <>
+      <Head>
+        <title>Blog - {CONFIG.title}</title>
+      </Head>
+      <Layout fullWidthGradientVariant={false}>
+        {articles.map((article) => {
+          return (
+            <div key={article.slug}>
+              <h1>{article.title}</h1>
+              <p>{article.description}</p>
+            </div>
+          )
+        })}
+      </Layout>
+    </>
+  )
+}
+
+export const getStaticProps: GetStaticProps<BlogProps> = async () => {
+  const articles = await getArticles()
+
+  return {
+    props: {
+      articles,
+    },
+    revalidate: DATA_CACHE_TIME_SECONDS,
+  }
+}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -6,12 +6,38 @@ import Head from 'next/head'
 import { TokenList, TokenListProps } from '@/components/TokensList'
 import { CONFIG } from '@/const/meta'
 import { Article, getArticles } from 'services/blog'
+import Link from 'next/link'
+import styled from 'styled-components'
+import { Color } from '@/styles/variables'
 
 const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
 
 export interface BlogProps {
   articles: Article[]
 }
+
+const Wrapper = styled.div`
+  h1 {
+    font-size: 3rem;
+    color: ${Color.white};
+  }
+`
+
+const ArticleItem = styled.article`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 126rem;
+  margin: 0 auto;
+  padding: 0 1.6rem;
+
+  a {
+    font-size: 1.6rem;
+    text-decoration: none;
+    color: ${Color.white};
+    margin: 1rem 0 0.5rem 0;
+  }
+`
 
 export default function BlogPage({ articles }: BlogProps) {
   return (
@@ -20,14 +46,17 @@ export default function BlogPage({ articles }: BlogProps) {
         <title>Blog - {CONFIG.title}</title>
       </Head>
       <Layout fullWidthGradientVariant={false}>
-        {articles.map((article) => {
-          return (
-            <div key={article.slug}>
-              <h1>{article.title}</h1>
-              <p>{article.description}</p>
-            </div>
-          )
-        })}
+        <Wrapper>
+          <h1>Blog</h1>
+          {articles.map((article) => {
+            return (
+              <ArticleItem key={article.slug}>
+                <Link href={`/blog/posts/${article.slug}`}>{article.title}</Link>
+                <p>{article.description}</p>
+              </ArticleItem>
+            )
+          })}
+        </Wrapper>
       </Layout>
     </>
   )

--- a/pages/blog/posts/[id].tsx
+++ b/pages/blog/posts/[id].tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import Head from 'next/head'
+import Layout from '@/components/Layout'
+
+import { GetStaticProps } from 'next'
+import { Article, getArticleBySlug, getArticleSlugs } from 'services/blog'
+import Link from 'next/link'
+import styled from 'styled-components'
+
+const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
+
+const Wrapper = styled.div`
+  a {
+    font-size: 1.2rem;
+    color: white;
+    margin: 1rem 0 0.5rem 0;
+  }
+`
+
+export interface BlogPostProps {
+  article: Article
+}
+
+export default function BlogPostPage({ article }: BlogPostProps) {
+  const { title, description, slug } = article
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} key="description" />
+        <meta property="og:title" content={title} key="og-title" />
+        <meta property="og:description" content={description} key="og-description" />
+        <meta name="twitter:title" content={title} key="twitter-title" />
+      </Head>
+
+      <Layout fullWidthGradientVariant={false}>
+        <Wrapper data-slug={slug}>
+          <h1>{title}</h1>
+          <p>{description}</p>
+          <Link href="/blog">Go back</Link>
+        </Wrapper>
+      </Layout>
+    </>
+  )
+}
+
+export async function getStaticPaths() {
+  const slugs = await getArticleSlugs()
+
+  return {
+    fallback: false,
+    paths: slugs.map((id) => ({ params: { id } })),
+  }
+}
+
+export const getStaticProps: GetStaticProps<BlogPostProps> = async ({ params }) => {
+  const article = await getArticleBySlug(params.slug as string)
+
+  if (!article) {
+    return {
+      notFound: true,
+    }
+  }
+
+  return {
+    props: {
+      article,
+    },
+    revalidate: DATA_CACHE_TIME_SECONDS,
+  }
+}

--- a/services/blog/index.ts
+++ b/services/blog/index.ts
@@ -6,13 +6,21 @@ export interface Article {
 
 /**
  *
+ * @returns Return all article slugs
+ */
+export async function getArticleSlugs(): Promise<string[]> {
+  return ['slug-1', 'slug-2', 'slug-3']
+}
+
+/**
+ *
  * @returns All articles
  */
 export async function getArticles(): Promise<Article[]> {
   return [
-    { title: 'Article 1', description: 'Description 1', slug: 'Slug 1' },
-    { title: 'Article 2', description: 'Description 2', slug: 'Slug 2' },
-    { title: 'Article 3', description: 'Description 3', slug: 'Slug 3' },
+    { title: 'Article 1', description: 'Description 1', slug: 'slug-1' },
+    { title: 'Article 2', description: 'Description 2', slug: 'slug-2' },
+    { title: 'Article 3', description: 'Description 3', slug: 'slug-3' },
   ]
 }
 
@@ -20,6 +28,6 @@ export async function getArticles(): Promise<Article[]> {
  *
  * @returns Single article
  */
-export async function getArticleById(id: string): Promise<Article> {
-  return { title: 'Article 1', description: 'Description 1', slug: 'Slug 1' }
+export async function getArticleBySlug(_slug: string): Promise<Article> {
+  return { title: 'Article 1', description: 'Description 1', slug: 'slug-1' }
 }

--- a/services/blog/index.ts
+++ b/services/blog/index.ts
@@ -1,0 +1,25 @@
+export interface Article {
+  title: string
+  description: string
+  slug: string
+}
+
+/**
+ *
+ * @returns All articles
+ */
+export async function getArticles(): Promise<Article[]> {
+  return [
+    { title: 'Article 1', description: 'Description 1', slug: 'Slug 1' },
+    { title: 'Article 2', description: 'Description 2', slug: 'Slug 2' },
+    { title: 'Article 3', description: 'Description 3', slug: 'Slug 3' },
+  ]
+}
+
+/**
+ *
+ * @returns Single article
+ */
+export async function getArticleById(id: string): Promise<Article> {
+  return { title: 'Article 1', description: 'Description 1', slug: 'Slug 1' }
+}


### PR DESCRIPTION
This PR kickstarts the blog. 

The scope is to prepare the project, to integrate with strapi. There will be a series of PRs for this.

So this is what is included in this one:

## Adds the menu
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/b10920bc-5eb5-41a7-8dad-c351ec142030)


## Adds blog page
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/7da39876-213f-4136-afea-d7f16612b4f1)

## Basic services
The service layer exposes 3 convenient methods:
- `getArticleSlugs(): Promise<string[]>`
- `getArticles(): Promise<Article[]`
- `getArticleBySlug(_slug: string): Promise<Article>`

# Test
- See blog: https://cowfi-git-add-blog-cowswap.vercel.app/blog
- See Blog post: https://cowfi-git-add-blog-cowswap.vercel.app/blog/posts/slug-1