### PR TITLE
Add link to CoW-AMM tutorial

### DIFF
--- a/pages/cow-amm.tsx
+++ b/pages/cow-amm.tsx
@@ -628,7 +628,21 @@ export default function CoWAMMPage({ siteConfigData }) {
 
             <SubTitle fontSize={2.9} lineHeight={1.4} color={Color.cowammBlack} maxWidth={100}>
               Anyone can provide liquidity to CoW AMM by creating their own protected pools. To get started, just follow
-              the instructions in the CoW DAO docs!
+              the
+              <a
+                onClick={() =>
+                  sendGAEventHandler({
+                    category: GAEventCategories.COWAMM,
+                    action: 'Content link click - instructions',
+                  })
+                }
+                href="https://docs.cow.fi/cow-protocol/tutorials/cow-amm-deployer"
+                target="_blank"
+                rel="noreferrer nofollow"
+              >
+                instructions
+              </a>{' '}
+              in the CoW DAO docs!
             </SubTitle>
 
             <ButtonWrapper center>

--- a/pages/cow-amm.tsx
+++ b/pages/cow-amm.tsx
@@ -628,7 +628,7 @@ export default function CoWAMMPage({ siteConfigData }) {
 
             <SubTitle fontSize={2.9} lineHeight={1.4} color={Color.cowammBlack} maxWidth={100}>
               Anyone can provide liquidity to CoW AMM by creating their own protected pools. To get started, just follow
-              the 
+              the&nbsp;
               <a
                 onClick={() =>
                   sendGAEventHandler({
@@ -640,7 +640,7 @@ export default function CoWAMMPage({ siteConfigData }) {
                 target="_blank"
                 rel="noreferrer nofollow"
               >
-                 instructions
+                instructions
               </a>{' '}
               in the CoW DAO docs!
             </SubTitle>

--- a/pages/cow-amm.tsx
+++ b/pages/cow-amm.tsx
@@ -640,7 +640,7 @@ export default function CoWAMMPage({ siteConfigData }) {
                 target="_blank"
                 rel="noreferrer nofollow"
               >
-                instructions
+                 instructions
               </a>{' '}
               in the CoW DAO docs!
             </SubTitle>

--- a/pages/cow-amm.tsx
+++ b/pages/cow-amm.tsx
@@ -628,7 +628,7 @@ export default function CoWAMMPage({ siteConfigData }) {
 
             <SubTitle fontSize={2.9} lineHeight={1.4} color={Color.cowammBlack} maxWidth={100}>
               Anyone can provide liquidity to CoW AMM by creating their own protected pools. To get started, just follow
-              the
+              the 
               <a
                 onClick={() =>
                   sendGAEventHandler({

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,17 @@ export default function HomePage({ metricsData, siteConfigData }: HomeProps) {
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = CONFIG
-  const { volumeUsd, volumeEth } = await cowSdk.cowSubgraphApi.getTotals()
+  let volumeUsd = 0
+  let volumeEth = 0
+
+  // Don't fail when couldn't get Subgraph data
+  try {
+    const data = await cowSdk.cowSubgraphApi.getTotals()
+    volumeUsd = data.volumeUsd
+    volumeEth = data.volumeEth
+  } catch (e) {
+    console.error(e)
+  }
   const { surplus, totalTrades, lastModified } = await getCowStats()
 
   const totalSurplus = surplus.reasonable + surplus.unusual


### PR DESCRIPTION
This PR attempts to add a link to the docs.cow.fi tutorial for setting up a CoW AMM. Although I think the link should be more visible and at the top of the page, this is the only thing i could do as i am very ignorant about TypeScript and how the whole cow.fi was structured.