### PR TITLE
Update Talk to Us Link

### DIFF
--- a/pages/widget/index.tsx
+++ b/pages/widget/index.tsx
@@ -70,7 +70,7 @@ const DAO_LOGOS_PATH = '/images/dao-logos/'
 
 const CONTENT = {
   configuratorURL: 'https://widget.cow.fi/',
-  calendlyURL: 'https://calendly.com/crystal-cow/cow-swap-widget',
+  calendlyURL: 'https://cowprotocol.typeform.com/to/rONXaxHV',
   docsURL: 'https://docs.cow.fi/cow-protocol/tutorials/widget',
   everyBell: [
     {


### PR DESCRIPTION
left the key as calendlyURL, but the URL has been changed to a typeform for Talk to Us as we are no longer subscribing to Calendly