### PR TITLE
fix(widget): enable connect wallet

### DIFF
--- a/pages/widget/index.tsx
+++ b/pages/widget/index.tsx
@@ -172,7 +172,8 @@ const DATA_CACHE_TIME_SECONDS = 5 * 60 // Cache 5min
 
 const widgetParams: CowSwapWidgetParams = {
   appCode: 'CoW Protocol: Widget Demo',
-  theme: 'light'
+  theme: 'light',
+  standaloneMode: true
 }
 
 export default function WidgetPage({ siteConfigData }) {


### PR DESCRIPTION
The "Connect wallet" doesn't work because `standaloneMode` is not enabled

![image](https://github.com/cowprotocol/cow-fi/assets/7122625/b872721c-c9af-4622-adbe-f8fce1f90080)
