### PR TITLE
Add default value for USD volume in case the query fails

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,9 +8,13 @@ import Layout from '@/components/Layout'
 import { CowSdk } from '@cowprotocol/cow-sdk'
 import { getCowStats } from 'services/cow'
 import Home, { HomeProps } from '@/components/Home'
+
 const cowSdk = new CowSdk(1)
 const numberFormatter = Intl.NumberFormat('en', { notation: 'compact' })
 const DATA_CACHE_TIME_SECONDS = 5 * 60 // Cache 5min
+
+// Defaults are only meant to be used when the API fails
+const DEFAULT_USD_VOLUME = '2548024217' // https://dune.com/cowprotocol/cowswap-high-level-metrics-dashboard?Aggregate+by_e759c2=Week
 
 export default function HomePage({ metricsData, siteConfigData }: HomeProps) {
   return (
@@ -28,16 +32,14 @@ export default function HomePage({ metricsData, siteConfigData }: HomeProps) {
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = CONFIG
-  let volumeUsd = 0
-  let volumeEth = 0
+  let volumeUsd = DEFAULT_USD_VOLUME
 
   // Don't fail when couldn't get Subgraph data
   try {
     const data = await cowSdk.cowSubgraphApi.getTotals()
     volumeUsd = data.volumeUsd
-    volumeEth = data.volumeEth
   } catch (e) {
-    console.error(e)
+    console.error('Error getting totals from Dune', e)
   }
   const { surplus, totalTrades, lastModified } = await getCowStats()
 
@@ -48,7 +50,6 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
     props: {
       metricsData: {
         totalVolume: numberFormatter.format(+volumeUsd) + '+',
-        totalVolumeETH: numberFormatter.format(+volumeEth) + '+',
 
         tradesCount: numberFormatter.format(totalTrades) + '+',
         tradesCountLastModified: lastModifiedFormatted,


### PR DESCRIPTION
Graph is down. 

While we don't get the new one working, I just hardcoded the latest value of the volume so we don't show a zero

Before:
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/816e3f96-8f8f-4bbb-8ff1-a7cc47338de0)

After:
<img width="1413" alt="image" src="https://github.com/cowprotocol/cow-fi/assets/2352112/efa27a3a-592e-4912-b756-0a763d3b955e">



## Error
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/7d5a5865-2732-483e-9de5-c5586d78636a)

![image](https://github.com/cowprotocol/cow-fi/assets/2352112/e195e70b-4c15-41a9-855e-f3520feab088)

## Test
- Open the link and check the volume is alright