### PR TITLE
Setup dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "NodeJS Alpine",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+
+	// "features": {
+	// },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+  "portsAttributes": {
+    "3000": {
+      "label": "cow.fi",
+      "onAutoForward": "notify"
+    }
+  },
+  
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "yarn install",
+
+
+	// Configure tool-specific properties.
+	"customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": ["streetsidesoftware.code-spell-checker"]
+    }
+  },
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
Setup dev-container to allow predictable dev setup.

## Context
For some reason, I started to get some error in my local dev setup that affected only this project. Other devs didn't have this issue. So after losing more time I wanted to loose on this, I decided to use `dev-containers` in vs code to make the development process more predictable

## Test

Build the dev container
<img width="377" alt="image" src="https://github.com/cowprotocol/cow-fi/assets/2352112/cac5ea81-f7e1-42c6-8805-6c4867c128c4">


Make sure the terminal allows you to start the app and build it
- `yarn dev`
- `yarn build`

<img width="1661" alt="image" src="https://github.com/cowprotocol/cow-fi/assets/2352112/36dcda85-173b-4702-adc4-d816d93d6d80">
