### PR TITLE
Add swagger UI

### DIFF
--- a/public/api/cms.html
+++ b/public/api/cms.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="SwaggerUI" />
+  <title>SwaggerUI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: 'https://cms.cow.fi/api/docs/openapi.json',
+        dom_id: '#swagger-ui',
+      });
+    };
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds swagger UI into the project. 

So far, we only had the Open API specification:
https://cms.cow.fi/api/docs/openapi.json

This adds a Swagger UI that uses that specification.
This makes it easier to understand the API definitions


## Test
- Open: https://cowfi-git-add-swagger-ui-cowswap.vercel.app/api/cms.html