### PR TITLE
Improve generation of pages

### DIFF
--- a/pages/learn/articles/[articleSlug].tsx
+++ b/pages/learn/articles/[articleSlug].tsx
@@ -17,21 +17,21 @@ export default function BlogPostPage({ article }: BlogPostProps) {
   return <ArticleContent article={article} />
 }
 
-type ArticleQuery = { slug: string}
+type ArticleQuery = { articleSlug: string}
 
 export const getStaticPaths: GetStaticPaths<ArticleQuery> = async () => {
   const allSlugs = await getAllArticleSlugs()
 
   return {
     fallback: false,
-    paths: allSlugs.map((slug) => ({
-      params: { slug }
+    paths: allSlugs.map((articleSlug) => ({
+      params: { articleSlug }
     })),
   }
 }
 
 export const getStaticProps: GetStaticProps<BlogPostProps, ArticleQuery> = async ({ params }) => {
-  const article = await getArticleBySlug(params.slug)
+  const article = await getArticleBySlug(params.articleSlug)
 
   if (!article) {
     return {

--- a/pages/learn/categories/[categorySlug].tsx
+++ b/pages/learn/categories/[categorySlug].tsx
@@ -17,21 +17,21 @@ export default function CategoryPage({ category }: CategoryPageProps) {
   return <CategoryContent category={category} />
 }
 
-type CategoryQuery = { slug: string}
+type CategoryQuery = { categorySlug: string}
 
 export const getStaticPaths: GetStaticPaths<CategoryQuery> = async () => {
   const allSlugs = await getAllCategorySlugs()
 
   return {
     fallback: false,
-    paths: allSlugs.map((slug) => ({
-      params: { slug }
+    paths: allSlugs.map((categorySlug) => ({
+      params: { categorySlug }
     })),
   }
 }
 
 export const getStaticProps: GetStaticProps<CategoryPageProps, CategoryQuery> = async ({ params }) => {
-  const category = await getCategoryBySlug(params.slug)
+  const category = await getCategoryBySlug(params.categorySlug)
 
   if (!category) {
     return {

--- a/pages/tokens/[tokenId].tsx
+++ b/pages/tokens/[tokenId].tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 import Layout from '@/components/Layout'
 import { getTokensIds as getTokensIds, getTokenDetails as getTokenDetails } from 'services/tokens'
 import { TokenDetails as TokenDetailsPure, TokenDetailProps } from '@/components/TokenDetails'
-import { GetStaticProps } from 'next'
+import { GetStaticPaths, GetStaticProps } from 'next'
 import { CONFIG } from '@/const/meta'
 
 const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
@@ -36,17 +36,19 @@ export default function TokenDetailsPage({ token }: TokenDetailPageProps) {
   )
 }
 
-export async function getStaticPaths() {
+type TokenQuery = { tokenId: string}
+
+export const getStaticPaths: GetStaticPaths<TokenQuery> = async () => {
   const tokenIds = await getTokensIds()
 
   return {
     fallback: false,
-    paths: tokenIds.map((id) => ({ params: { id } })),
+    paths: tokenIds.map((tokenId) => ({ params: { tokenId } })),
   }
 }
 
-export const getStaticProps: GetStaticProps<TokenDetailProps> = async ({ params }) => {
-  const token = await getTokenDetails(params.id as string)
+export const getStaticProps: GetStaticProps<TokenDetailProps, TokenQuery> = async ({ params }) => {
+  const token = await getTokenDetails(params.tokenId)
 
   if (!token) {
     return {


### PR DESCRIPTION
This PR just improves the type checking and name convention for the page generation:
- Fixes the types for the token generation
- Use a better name for the params and file names. Before we had multiple files with the same name and I feel is easier to find them now

Before:
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/c5434cb8-cae2-4113-988e-f61be3ad5305)


After:
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/dbb2a43f-437b-43f9-8a4f-76024ba8c709)


One reason why is simpler, is that now you can open the category pages like this:
![image](https://github.com/cowprotocol/cow-fi/assets/2352112/533ccd2a-7789-4b58-9631-80b1c81b1777)
