### PR TITLE
Comment broken subgraph query

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,13 +34,14 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const siteConfigData = CONFIG
   let volumeUsd = DEFAULT_USD_VOLUME
 
-  // Don't fail when couldn't get Subgraph data
-  try {
-    const data = await cowSdk.cowSubgraphApi.getTotals()
-    volumeUsd = data.volumeUsd
-  } catch (e) {
-    console.error('Error getting totals from Dune', e)
-  }
+  // TODO: Fix this
+  // // Don't fail when couldn't get Subgraph data
+  // try {
+  //   const data = await cowSdk.cowSubgraphApi.getTotals()
+  //   volumeUsd = data.volumeUsd
+  // } catch (e) {
+  //   console.error('Error getting totals from Dune', e)
+  // }
   const { surplus, totalTrades, lastModified } = await getCowStats()
 
   const totalSurplus = surplus.reasonable + surplus.unusual


### PR DESCRIPTION
Subgraph query is broken, so there's no much point on "attempting to get the data" from there.

![image](https://github.com/cowprotocol/cow-fi/assets/2352112/158853d9-dc0e-427f-b36f-c8d87695403f)

This PR don't fix it, but we at least we don't attempt it any more. 

The fix needs to come later when we either:
- Deploy thegraph: @alfetopito gave it a try, but there was some issues
- Move the stats to the CMS (should be easy! but I don't want to deal with this distraction now)
- Find an alternative source for the volume and general stats: dune? defillama? other? 

I made this issue to follow up in another moment: https://github.com/cowprotocol/cowswap/issues/4367 